### PR TITLE
fix(metrics): add input validation to calcStats and removeOutliers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - YYYY-MM-DD
+
+### Fixed
+- `calcStats()` and `removeOutliers()` now validate input and throw a descriptive error on invalid data (non-array, empty array, non-number elements, NaN elements), matching `calcQuantile()`'s existing contract. Previously, `calcStats([])` silently returned an all-nulls `Stats` object; it now throws. This is a behavioral breaking change for callers relying on the empty-array graceful return.
+- `calcQuantile()`, `calcStats()`, and `removeOutliers()` now correctly reject sparse arrays (e.g., `[1, , 3]`). Previously, `Array.prototype.some` skipped empty slots, allowing sparse arrays to pass validation and silently inject `NaN` into calculations.
+
 ## [1.2.0] - 2026-04-02
 
 ### Added

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -6,6 +6,10 @@
  * For datasets with fewer than 4 elements, returns a copy unchanged (IQR is unreliable).
  */
 export function removeOutliers(data: number[]): number[] {
+    if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
+    for (const v of data) {
+        if (typeof v !== 'number' || Number.isNaN(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+    }
     if (data.length < 4) return [...data];
     const sorted = [...data].sort((a, b) => a - b);
     const q1 = calcQuantileOnSorted(0.25, sorted);
@@ -18,7 +22,10 @@ export function removeOutliers(data: number[]): number[] {
 
 export function calcQuantile(q: number, data: number[]): number {
     if (!Number.isInteger(q) || q <= 0 || q > 100) throw new Error("Quantile must be an integer greater than 0 and less than or equal to 100");
-    if (!data || !Array.isArray(data) || data.length === 0 || data.some(v => typeof v !== 'number' || Number.isNaN(v))) throw new Error("Data must be an array of numbers and must contain at least one element");
+    if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
+    for (const v of data) {
+        if (typeof v !== 'number' || Number.isNaN(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+    }
     const sorted = [...data].sort((a, b) => a - b);
     return calcQuantileOnSorted(q / 100, sorted);
 }
@@ -93,18 +100,12 @@ function getCriticalValue(n: number): { method: "z" | "t"; value: number } {
  * Confidence intervals use Student's t-distribution for n <= 30, z-distribution for n >= 31.
  */
 export function calcStats(data: number[]): Stats {
+    if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
+    for (const v of data) {
+        if (typeof v !== 'number' || Number.isNaN(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+    }
     const n = data.length;
     const warnings: string[] = [];
-
-    if (n === 0) {
-        warnings.push("Empty dataset: no statistics can be computed");
-        return {
-            n, min: null, max: null, mean: null, median: null, stddev: null,
-            marginOfError: null, relativeMarginOfError: null, confidenceInterval: null,
-            coefficientOfVariation: null, isSmallSample: true, confidenceMethod: null,
-            confidenceCriticalValue: null, warnings
-        };
-    }
 
     const sorted = [...data].sort((a, b) => a - b);
     const min = sorted[0];

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -32,7 +32,9 @@ describe("Test calcQuantile function", () => {
         ["null", null],
         ["not an array", "string"],
         ["not an array of numbers", ["NaN", "0.2"]],
-        ["an empty array", []]
+        ["an empty array", []],
+        // eslint-disable-next-line no-sparse-arrays
+        ["a sparse array", [1, , 3]]
     ])("should throw an error when data is %s", (description, data) => {
         // @ts-expect-error - intentionally passing invalid data for testing
         expect(() => calcQuantile(50, data)).toThrowError(/Data must be an array of numbers and must contain at least one element/);
@@ -84,6 +86,20 @@ describe("Test removeOutliers function", () => {
         const result = removeOutliers(data);
         expect(result).toEqual([5, 5, 5, 5, 5]);
     });
+
+    test.each([
+        ["undefined", undefined],
+        ["null", null],
+        ["not an array", "string"],
+        ["not an array of numbers", ["1", "2", "3", "4"]],
+        ["an empty array", []],
+        ["an array containing NaN", [1, NaN, 3, 4]],
+        // eslint-disable-next-line no-sparse-arrays
+        ["a sparse array", [1, , 3, 4]],
+    ])("should throw an error when data is %s", (description, data) => {
+        // @ts-expect-error - intentionally passing invalid data for testing
+        expect(() => removeOutliers(data)).toThrowError(/Data must be an array of numbers and must contain at least one element/);
+    });
 });
 
 describe("Test calcStats function", () => {
@@ -132,22 +148,18 @@ describe("Test calcStats function", () => {
         expect(stats.coefficientOfVariation).toBeCloseTo(Math.sqrt(2.5) / 3, 10);
     });
 
-    test("should return nulls for empty dataset (n=0)", () => {
-        const stats = calcStats([]);
-        expect(stats.n).toBe(0);
-        expect(stats.min).toBeNull();
-        expect(stats.max).toBeNull();
-        expect(stats.mean).toBeNull();
-        expect(stats.median).toBeNull();
-        expect(stats.stddev).toBeNull();
-        expect(stats.marginOfError).toBeNull();
-        expect(stats.relativeMarginOfError).toBeNull();
-        expect(stats.confidenceInterval).toBeNull();
-        expect(stats.coefficientOfVariation).toBeNull();
-        expect(stats.isSmallSample).toBe(true);
-        expect(stats.confidenceMethod).toBeNull();
-        expect(stats.confidenceCriticalValue).toBeNull();
-        expect(stats.warnings).toContain("Empty dataset: no statistics can be computed");
+    test.each([
+        ["undefined", undefined],
+        ["null", null],
+        ["not an array", "string"],
+        ["not an array of numbers", ["1", "2", "3", "4"]],
+        ["an empty array", []],
+        ["an array containing NaN", [1, NaN, 3, 4]],
+        // eslint-disable-next-line no-sparse-arrays
+        ["a sparse array", [1, , 3, 4]],
+    ])("should throw an error when data is %s", (description, data) => {
+        // @ts-expect-error - intentionally passing invalid data for testing
+        expect(() => calcStats(data)).toThrowError(/Data must be an array of numbers and must contain at least one element/);
     });
 
     test("should return null stddev and CI for a single value (n=1)", () => {


### PR DESCRIPTION
## Summary
- `calcStats()` and `removeOutliers()` now throw `Error("Data must be an array of numbers and must contain at least one element")` on invalid input, matching `calcQuantile()`'s existing contract.
- The `calcStats([])` graceful all-nulls return is removed (classified as a bug — silent failure is misleading).
- Fixes a sparse array vulnerability in all three functions: `Array.prototype.some` skips empty slots in sparse arrays (e.g., `[1, , 3]`), allowing them to pass validation and silently inject `NaN` into calculations. Now uses `for...of` which correctly yields `undefined` for holes.
- 7 validation test cases added for each of `removeOutliers` and `calcStats`; 1 sparse array test added to `calcQuantile`.

## Breaking change
`calcStats([])` previously returned an all-nulls `Stats` object. It now throws. `removeOutliers([])` previously returned `[]`. It now throws. External consumers relying on this behavior must be updated.

## Test plan
- [x] All existing tests in `test/metrics.test.ts` and `test/main.test.ts` pass (113 total)
- [x] 100% statement and branch coverage maintained
- [x] `npm run lint` — zero errors
- [x] `npm run build` — compiles cleanly
- [x] SonarCloud: 0 bugs, 0 vulnerabilities, 0 new code smells
- [x] `removeOutliers([1, 2, 100])` (n=3) still returns copy without throwing
- [x] `calcStats([42])` (n=1) still works

Closes #11