### PR TITLE
fix: reject Infinity/-Infinity in input validation

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -8,7 +8,7 @@
 export function removeOutliers(data: number[]): number[] {
     if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
     for (const v of data) {
-        if (typeof v !== 'number' || Number.isNaN(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+        if (!Number.isFinite(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
     }
     if (data.length < 4) return [...data];
     const sorted = [...data].sort((a, b) => a - b);
@@ -24,7 +24,7 @@ export function calcQuantile(q: number, data: number[]): number {
     if (!Number.isInteger(q) || q <= 0 || q > 100) throw new Error("Quantile must be an integer greater than 0 and less than or equal to 100");
     if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
     for (const v of data) {
-        if (typeof v !== 'number' || Number.isNaN(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+        if (!Number.isFinite(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
     }
     const sorted = [...data].sort((a, b) => a - b);
     return calcQuantileOnSorted(q / 100, sorted);
@@ -104,7 +104,7 @@ function getCriticalValue(n: number): { method: "z" | "t"; value: number } {
 export function calcStats(data: number[]): Stats {
     if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
     for (const v of data) {
-        if (typeof v !== 'number' || Number.isNaN(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+        if (!Number.isFinite(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
     }
     const n = data.length;
     const warnings: string[] = [];

--- a/src/shape.ts
+++ b/src/shape.ts
@@ -6,7 +6,7 @@ export interface ShapeDiagnostics {
 function validateData(data: number[]): void {
     if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
     for (const v of data) {
-        if (typeof v !== 'number' || Number.isNaN(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+        if (!Number.isFinite(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
     }
 }
 

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -33,6 +33,8 @@ describe("Test calcQuantile function", () => {
         ["not an array", "string"],
         ["not an array of numbers", ["NaN", "0.2"]],
         ["an empty array", []],
+        ["an array containing Infinity", [1, Infinity, 3]],
+        ["an array containing -Infinity", [1, -Infinity, 3]],
         // eslint-disable-next-line no-sparse-arrays
         ["a sparse array", [1, , 3]]
     ])("should throw an error when data is %s", (description, data) => {
@@ -94,6 +96,8 @@ describe("Test removeOutliers function", () => {
         ["not an array of numbers", ["1", "2", "3", "4"]],
         ["an empty array", []],
         ["an array containing NaN", [1, NaN, 3, 4]],
+        ["an array containing Infinity", [1, Infinity, 3, 4]],
+        ["an array containing -Infinity", [1, -Infinity, 3, 4]],
         // eslint-disable-next-line no-sparse-arrays
         ["a sparse array", [1, , 3, 4]],
     ])("should throw an error when data is %s", (description, data) => {
@@ -155,6 +159,8 @@ describe("Test calcStats function", () => {
         ["not an array of numbers", ["1", "2", "3", "4"]],
         ["an empty array", []],
         ["an array containing NaN", [1, NaN, 3, 4]],
+        ["an array containing Infinity", [1, Infinity, 3, 4]],
+        ["an array containing -Infinity", [1, -Infinity, 3, 4]],
         // eslint-disable-next-line no-sparse-arrays
         ["a sparse array", [1, , 3, 4]],
     ])("should throw an error when data is %s", (description, data) => {

--- a/test/shape.test.ts
+++ b/test/shape.test.ts
@@ -11,6 +11,8 @@ describe("Test calcShapeDiagnostics function", () => {
             ["not an array of numbers", ["1", "2", "3"]],
             ["an empty array", []],
             ["an array containing NaN", [1, NaN, 3]],
+            ["an array containing Infinity", [1, Infinity, 3]],
+            ["an array containing -Infinity", [1, -Infinity, 3]],
             // eslint-disable-next-line no-sparse-arrays
             ["a sparse array", [1, , 3]],
         ])("should throw an error when data is %s", (description, data) => {


### PR DESCRIPTION
## Summary

- Replace `typeof v !== 'number' || Number.isNaN(v)` with `!Number.isFinite(v)` in all 4 data-array validators (`calcStats`, `calcQuantile`, `removeOutliers` in `src/metrics.ts`, `validateData` in `src/shape.ts`)
- Add `Infinity` and `-Infinity` test cases to all 4 corresponding `test.each` validation tables

Closes #45

## Test plan

- [x] `npm test` — 167 tests pass, 100% statement + branch coverage
- [x] `npm run lint` — zero errors
- [x] `npm run build` — compiles cleanly
- [x] SonarCloud: 0 bugs, 0 vulnerabilities, 0 new code smells