### PR TITLE
fix: correct misleading Rule 3 comment in calcShapeDiagnostics

### DIFF
--- a/src/shape.ts
+++ b/src/shape.ts
@@ -72,7 +72,7 @@ export function calcShapeDiagnostics(data: number[], skewness: number | null, st
         return { label: "constant", sparkline };
     }
 
-    // Rule 3: skewness unavailable (e.g. n=2 with non-null stddev)
+    // Rule 3: skewness unavailable despite n >= 3 and stddev > 0 (defensive guard; unreachable via calcStats)
     if (skewness === null) {
         return { label: "insufficient data", sparkline };
     }


### PR DESCRIPTION
## Summary
- Corrects the misleading comment on Rule 3 in `calcShapeDiagnostics` (`src/shape.ts:75`)
- The old comment cited `n=2` as an example trigger, but `n=2` is caught by Rule 1 (`n < 3`) and never reaches Rule 3
- New comment accurately describes Rule 3 as a defensive guard for when `skewness` is `null` despite `n >= 3` and `stddev > 0`

Closes #47

## Test plan
- [x] All 167 tests pass
- [x] 100% statement + branch coverage maintained
- [x] Zero lint errors
- [x] Clean build
- [x] SonarCloud: no new issues introduced