### PR TITLE
fix: use distinct error messages for different validation failure modes

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -6,9 +6,10 @@
  * For datasets with fewer than 4 elements, returns a copy unchanged (IQR is unreliable).
  */
 export function removeOutliers(data: number[]): number[] {
-    if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
-    for (const v of data) {
-        if (!Number.isFinite(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+    if (!Array.isArray(data)) throw new Error("Data is required and must be an array");
+    if (data.length === 0) throw new Error("Data must contain at least one element");
+    for (let i = 0; i < data.length; i++) {
+        if (!Number.isFinite(data[i])) throw new Error(`Data must contain only finite numbers, but found ${String(data[i])} at index ${i}`);
     }
     if (data.length < 4) return [...data];
     const sorted = [...data].sort((a, b) => a - b);
@@ -22,9 +23,10 @@ export function removeOutliers(data: number[]): number[] {
 
 export function calcQuantile(q: number, data: number[]): number {
     if (!Number.isInteger(q) || q <= 0 || q > 100) throw new Error("Quantile must be an integer greater than 0 and less than or equal to 100");
-    if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
-    for (const v of data) {
-        if (!Number.isFinite(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+    if (!Array.isArray(data)) throw new Error("Data is required and must be an array");
+    if (data.length === 0) throw new Error("Data must contain at least one element");
+    for (let i = 0; i < data.length; i++) {
+        if (!Number.isFinite(data[i])) throw new Error(`Data must contain only finite numbers, but found ${String(data[i])} at index ${i}`);
     }
     const sorted = [...data].sort((a, b) => a - b);
     return calcQuantileOnSorted(q / 100, sorted);
@@ -102,9 +104,10 @@ function getCriticalValue(n: number): { method: "z" | "t"; value: number } {
  * Confidence intervals use Student's t-distribution for n <= 30, z-distribution for n >= 31.
  */
 export function calcStats(data: number[]): Stats {
-    if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
-    for (const v of data) {
-        if (!Number.isFinite(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+    if (!Array.isArray(data)) throw new Error("Data is required and must be an array");
+    if (data.length === 0) throw new Error("Data must contain at least one element");
+    for (let i = 0; i < data.length; i++) {
+        if (!Number.isFinite(data[i])) throw new Error(`Data must contain only finite numbers, but found ${String(data[i])} at index ${i}`);
     }
     const n = data.length;
     const warnings: string[] = [];

--- a/src/shape.ts
+++ b/src/shape.ts
@@ -4,9 +4,10 @@ export interface ShapeDiagnostics {
 }
 
 function validateData(data: number[]): void {
-    if (!data || !Array.isArray(data) || data.length === 0) throw new Error("Data must be an array of numbers and must contain at least one element");
-    for (const v of data) {
-        if (!Number.isFinite(v)) throw new Error("Data must be an array of numbers and must contain at least one element");
+    if (!Array.isArray(data)) throw new Error("Data is required and must be an array");
+    if (data.length === 0) throw new Error("Data must contain at least one element");
+    for (let i = 0; i < data.length; i++) {
+        if (!Number.isFinite(data[i])) throw new Error(`Data must contain only finite numbers, but found ${String(data[i])} at index ${i}`);
     }
 }
 

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -31,16 +31,31 @@ describe("Test calcQuantile function", () => {
         ["undefined", undefined],
         ["null", null],
         ["not an array", "string"],
+    ])("should throw an error when data is %s (not an array)", (description, data) => {
+        // @ts-expect-error - intentionally passing invalid data for testing
+        expect(() => calcQuantile(50, data)).toThrowError(/Data is required and must be an array/);
+    });
+
+    test("should throw an error when data is an empty array", () => {
+        expect(() => calcQuantile(50, [])).toThrowError(/Data must contain at least one element/);
+    });
+
+    test.each([
         ["not an array of numbers", ["NaN", "0.2"]],
-        ["an empty array", []],
+        ["an array containing NaN", [1, NaN, 3]],
         ["an array containing Infinity", [1, Infinity, 3]],
         ["an array containing -Infinity", [1, -Infinity, 3]],
         // eslint-disable-next-line no-sparse-arrays
-        ["a sparse array", [1, , 3]]
-    ])("should throw an error when data is %s", (description, data) => {
+        ["a sparse array", [1, , 3]],
+    ])("should throw an error when data is %s (non-finite element)", (description, data) => {
         // @ts-expect-error - intentionally passing invalid data for testing
-        expect(() => calcQuantile(50, data)).toThrowError(/Data must be an array of numbers and must contain at least one element/);
+        expect(() => calcQuantile(50, data)).toThrowError(/Data must contain only finite numbers/);
     });
+
+    test("should report the correct index in the non-finite element error message", () => {
+        expect(() => calcQuantile(50, [1, NaN, 3])).toThrowError(/found NaN at index 1/);
+    });
+
     test.each([
         ["undefined", undefined],
         ["null", null],
@@ -93,16 +108,29 @@ describe("Test removeOutliers function", () => {
         ["undefined", undefined],
         ["null", null],
         ["not an array", "string"],
+    ])("should throw an error when data is %s (not an array)", (description, data) => {
+        // @ts-expect-error - intentionally passing invalid data for testing
+        expect(() => removeOutliers(data)).toThrowError(/Data is required and must be an array/);
+    });
+
+    test("should throw an error when data is an empty array", () => {
+        expect(() => removeOutliers([])).toThrowError(/Data must contain at least one element/);
+    });
+
+    test.each([
         ["not an array of numbers", ["1", "2", "3", "4"]],
-        ["an empty array", []],
         ["an array containing NaN", [1, NaN, 3, 4]],
         ["an array containing Infinity", [1, Infinity, 3, 4]],
         ["an array containing -Infinity", [1, -Infinity, 3, 4]],
         // eslint-disable-next-line no-sparse-arrays
         ["a sparse array", [1, , 3, 4]],
-    ])("should throw an error when data is %s", (description, data) => {
+    ])("should throw an error when data is %s (non-finite element)", (description, data) => {
         // @ts-expect-error - intentionally passing invalid data for testing
-        expect(() => removeOutliers(data)).toThrowError(/Data must be an array of numbers and must contain at least one element/);
+        expect(() => removeOutliers(data)).toThrowError(/Data must contain only finite numbers/);
+    });
+
+    test("should report the correct index in the non-finite element error message", () => {
+        expect(() => removeOutliers([10, 11, Infinity, 13])).toThrowError(/found Infinity at index 2/);
     });
 });
 
@@ -156,16 +184,29 @@ describe("Test calcStats function", () => {
         ["undefined", undefined],
         ["null", null],
         ["not an array", "string"],
+    ])("should throw an error when data is %s (not an array)", (description, data) => {
+        // @ts-expect-error - intentionally passing invalid data for testing
+        expect(() => calcStats(data)).toThrowError(/Data is required and must be an array/);
+    });
+
+    test("should throw an error when data is an empty array", () => {
+        expect(() => calcStats([])).toThrowError(/Data must contain at least one element/);
+    });
+
+    test.each([
         ["not an array of numbers", ["1", "2", "3", "4"]],
-        ["an empty array", []],
         ["an array containing NaN", [1, NaN, 3, 4]],
         ["an array containing Infinity", [1, Infinity, 3, 4]],
         ["an array containing -Infinity", [1, -Infinity, 3, 4]],
         // eslint-disable-next-line no-sparse-arrays
         ["a sparse array", [1, , 3, 4]],
-    ])("should throw an error when data is %s", (description, data) => {
+    ])("should throw an error when data is %s (non-finite element)", (description, data) => {
         // @ts-expect-error - intentionally passing invalid data for testing
-        expect(() => calcStats(data)).toThrowError(/Data must be an array of numbers and must contain at least one element/);
+        expect(() => calcStats(data)).toThrowError(/Data must contain only finite numbers/);
+    });
+
+    test("should report the correct index in the non-finite element error message", () => {
+        expect(() => calcStats([5, 10, -Infinity, 20])).toThrowError(/found -Infinity at index 2/);
     });
 
     test("should return null stddev and CI for a single value (n=1)", () => {

--- a/test/shape.test.ts
+++ b/test/shape.test.ts
@@ -8,16 +8,29 @@ describe("Test calcShapeDiagnostics function", () => {
             ["undefined", undefined],
             ["null", null],
             ["not an array", "string"],
+        ])("should throw an error when data is %s (not an array)", (description, data) => {
+            // @ts-expect-error - intentionally passing invalid data for testing
+            expect(() => calcShapeDiagnostics(data, null, null)).toThrowError(/Data is required and must be an array/);
+        });
+
+        test("should throw an error when data is an empty array", () => {
+            expect(() => calcShapeDiagnostics([], null, null)).toThrowError(/Data must contain at least one element/);
+        });
+
+        test.each([
             ["not an array of numbers", ["1", "2", "3"]],
-            ["an empty array", []],
             ["an array containing NaN", [1, NaN, 3]],
             ["an array containing Infinity", [1, Infinity, 3]],
             ["an array containing -Infinity", [1, -Infinity, 3]],
             // eslint-disable-next-line no-sparse-arrays
             ["a sparse array", [1, , 3]],
-        ])("should throw an error when data is %s", (description, data) => {
+        ])("should throw an error when data is %s (non-finite element)", (description, data) => {
             // @ts-expect-error - intentionally passing invalid data for testing
-            expect(() => calcShapeDiagnostics(data, null, null)).toThrowError(/Data must be an array of numbers and must contain at least one element/);
+            expect(() => calcShapeDiagnostics(data, null, null)).toThrowError(/Data must contain only finite numbers/);
+        });
+
+        test("should report the correct index in the non-finite element error message", () => {
+            expect(() => calcShapeDiagnostics([1, 2, NaN], null, null)).toThrowError(/found NaN at index 2/);
         });
     });
 


### PR DESCRIPTION
## Summary
- Replaces the uniform error message across all 4 data validators (`removeOutliers`, `calcQuantile`, `calcStats`, `validateData`) with 3 distinct messages per failure mode:
  - Not an array: `"Data is required and must be an array"`
  - Empty array: `"Data must contain at least one element"`
  - Non-finite element: `"Data must contain only finite numbers, but found <value> at index <i>"`
- Adds NaN test case to `calcQuantile` (was previously missing unlike other functions)
- Adds index accuracy assertions for all 4 validators

Closes #48

## Test plan
- [x] 172 tests pass (was 167, +5 new)
- [x] 100% statement + branch coverage
- [x] Zero lint errors
- [x] Clean build
- [x] SonarCloud: 0 new issues on all 4 changed files