### PR TITLE
ci: migrate SonarCloud action to sonarqube-scan-action@v5

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,7 @@ jobs:
     - run: npm run build
     - run: npm test
     - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@v5
+      uses: SonarSource/sonarqube-scan-action@v5
       env:
         #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Replaces deprecated `sonarsource/sonarcloud-github-action@v5` with official drop-in replacement `SonarSource/sonarqube-scan-action@v5`
- Eliminates deprecation warnings in CI runs

Closes #3
Closes #7

## Test plan
- [x] CI workflow syntax is valid YAML
- [x] CI run on PR confirms SonarCloud scan step exits 0 without deprecation warning