### PR TITLE
ci: upgrade checkout and setup-node actions to v6 for Node.js 24 runtime

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,9 +20,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,12 +11,11 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
-          always-auth: true
       - run: npm ci
       - run: npm run lint
       - run: npm test


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout` and `actions/setup-node` from v4 to v6 in both CI workflows (`node.js.yml`, `npm-publish.yml`)
- v6 runs on Node.js 24 runtime, eliminating deprecation warnings (deadline: June 2, 2026)
- Removes the now-inert `always-auth` parameter from `npm-publish.yml` (dropped from setup-node v6)
- No standalone `actions/cache` step exists — caching is handled via setup-node's built-in `cache` parameter

Closes #6

## Test plan
- [ ] CI run on PR confirms all matrix jobs (18.x, 20.x, 22.x) pass without deprecation warnings
- [ ] SonarCloud scan step unaffected