### PR TITLE
chore: add Node.js 24 to CI matrix and update @types/node

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,25 @@
 {
   "name": "jest-performance-matchers",
-  "version": "1.0.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jest-performance-matchers",
-      "version": "1.0.1",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "~27.0.0",
-        "@types/node": "~18.0.0",
+        "@types/node": "~18.19.0",
         "@typescript-eslint/eslint-plugin": "~5.31.0",
         "@typescript-eslint/parser": "~5.31.0",
         "eslint": "~8.20.0",
         "jest": "~27.0.0",
         "ts-jest": "~27.0.0",
         "typescript": "~4.7.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "jest": ">=27.0.0"
@@ -1153,10 +1156,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
-      "dev": true
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
@@ -4862,6 +4868,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -6050,10 +6062,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
-      "dev": true
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prettier": {
       "version": "2.7.1",
@@ -8781,6 +8796,12 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "~27.0.0",
-    "@types/node": "~18.0.0",
+    "@types/node": "~18.19.0",
     "@typescript-eslint/eslint-plugin": "~5.31.0",
     "@typescript-eslint/parser": "~5.31.0",
     "jest": "~27.0.0",
@@ -45,6 +45,9 @@
   },
   "peerDependencies": {
     "jest": ">=27.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   },
   "dependencies": {},
   "volta": {


### PR DESCRIPTION
## Summary
- Adds `24.x` to the Node.js version matrix in `node.js.yml`
- Updates `@types/node` from `~18.0.0` to `~18.19.0` (latest v18 series, verified compatible with TypeScript 4.7)
- Adds `"engines": { "node": ">=18.0.0" }` to `package.json` documenting supported versions
- The Volta pin (`node: 18.0.0`) is a local dev tool hint and is intentionally left as-is

Closes #8

## Test plan
- [x] `npm run build` compiles cleanly with TypeScript 4.7 + @types/node@~18.19.0
- [x] `npm run lint` — zero errors
- [x] `npm test` — 167 tests pass, 100% coverage
- [x] CI run confirms all 4 matrix jobs (18.x, 20.x, 22.x, 24.x) pass