### PR TITLE
feat: add interpretive annotations to benchmark failure diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you already have Jest tests, adding performance assertions takes one import a
 | **Accuracy** | ~1ms resolution | Sub-millisecond (`process.hrtime()`) |
 | **Flakiness** | Single run = noisy result | Multiple iterations + quantiles = stable |
 | **Outliers** | One GC pause fails the test | IQR-based outlier removal |
-| **Diagnostics** | You get a number | Mean, median, CI, percentiles, shape analysis, sparklines |
+| **Diagnostics** | You get a number | Mean, median, CI, percentiles, shape, sparklines, and actionable guidance |
 | **Warmup** | DIY or forget about it | Built-in warmup iterations |
 | **Statistics** | None built-in | Built-in — mean, CI, quantiles, outlier detection |
 | **Dependencies** | Grows with each need — more code to trust | Zero — nothing to audit, nothing to break |
@@ -49,7 +49,7 @@ If you already have Jest tests, adding performance assertions takes one import a
 - **Zero dependencies** — lightweight and safe to add; all statistics implemented in-house
 - **Full TypeScript support** — type declarations included, works seamlessly with `ts-jest`
 - **High-resolution timing** — `process.hrtime()` for sub-millisecond accuracy
-- **Statistical rigor** — 95% confidence intervals (Student's t / z), IQR outlier detection, skewness analysis, distribution shape classification, and rich diagnostics on failure
+- **Statistical rigor** — 95% confidence intervals (Student's t / z), IQR outlier detection, skewness analysis, distribution shape classification, quality tags, sample adequacy labels, and interpretive guidance on failure
 - **Warmup iterations** — exclude JIT compilation and cache warming from measurements
 - **Exported utilities** — use `calcStats()`, `calcQuantile()`, and `removeOutliers()` directly in your own code
 
@@ -214,24 +214,76 @@ await expect(async () => {
 When a quantile matcher fails, it outputs rich diagnostics to help you understand your performance profile:
 
 ```
-expected that 95% of the time when running 100 iterations,
-the function duration to be less or equal to 5 (ms),
-instead it was 8.34 (ms)
+expected that 95% of the time when running 50 iterations,
+the function duration to be less or equal to 10 (ms),
+instead it was 21.43 (ms)
 
-Statistics (n=100): mean=6.12ms, median=5.87ms, stddev=2.45ms
-95% CI: [5.63, 6.61]ms | RME: 7.99% | CV: 0.40
-Distribution: min=2.10ms | P25=4.50ms | P50=5.87ms | P75=7.20ms | P90=8.10ms | max=15.30ms
-Shape: right-skewed (skewness=0.85) | ▁▃▇█▅▃▂▁▁▁
+Statistics (n=50): mean=8.81ms, median=5.70ms, stddev=7.33ms
+Confidence Interval (CI): 95% [6.78, 10.85]ms
+Relative Margin of Error (RME): 23.05% [FAIR 10-30%]
+Coefficient of Variation (CV): 0.83 [POOR >0.3]
+Distribution: min=2.04ms | P25=4.21ms | P50=5.70ms | P75=11.52ms | P90=20.40ms | max=41.15ms
+Shape: right-skewed (skewness=2.26) | █▂▂▁▁▁
+Sample adequacy: GOOD >30 (n=50)
+Interpretation: mean is approximate and variance is high (RME: FAIR 10-30%,
+  CV: POOR >0.3) — increase iterations and investigate noise sources (GC, I/O,
+  scheduling). CI upper bound (10.85ms) exceeds your 10ms threshold — the true
+  mean likely exceeds your budget, consider optimizing the code or raising the
+  threshold
 ```
 
 The diagnostics include:
 - **Summary statistics** — mean, median, standard deviation, sample size
-- **95% confidence interval** — uses Student's t-distribution for n <= 30, z-distribution for n >= 31
-- **RME (Relative Margin of Error)** — margin of error as a percentage of the mean
-- **CV (Coefficient of Variation)** — standard deviation relative to the mean
+- **Confidence Interval (CI)** — the range `[lower, upper]ms` where the true mean likely falls. Uses Student's t-distribution for n <= 30, z-distribution for n >= 31
+- **Relative Margin of Error (RME)** — margin of error as a percentage of the mean, with classification tag (`[GOOD <10%]`/`[FAIR 10-30%]`/`[POOR >30%]`)
+- **Coefficient of Variation (CV)** — standard deviation relative to the mean, with classification tag (`[GOOD <0.1]`/`[FAIR 0.1-0.3]`/`[POOR >0.3]`)
 - **Distribution percentiles** — min, P25, P50, P75, P90, max
 - **Distribution shape** — skewness value, shape classification (symmetric, left-skewed, right-skewed, bimodal, constant), and an ASCII sparkline histogram for at-a-glance visualization. Shape diagnostics are most reliable with n > 100; smaller samples produce noisier sparklines and less stable labels
+- **Sample adequacy** — classifies sample size as `POOR` (< 10), `FAIR` (10-30), or `GOOD` (> 30)
+- **Interpretation** — single-sentence summary of result reliability based on RME and sample size
 - **Warnings** — contextual alerts (e.g., small sample size, empty dataset)
+
+### How to use each metric
+
+**95% Confidence Interval (CI)** — the range `[lower, upper]ms` where the true average execution time likely falls. If your performance budget is 50ms, check that the CI upper bound is below 50ms. If the upper bound is 55ms, there's a real chance the code is too slow even if the measured mean looks fine. The interpretation line will flag this automatically.
+
+**RME (Relative Margin of Error)** — how much the mean might shift if you ran the benchmark again. A low RME means you can trust the mean; a high RME means you need more data.
+
+| RME tag | Value | What it means |
+|---|---|---|
+| `[GOOD <10%]` | < 10% | Mean is stable — small regressions are detectable |
+| `[FAIR 10-30%]` | 10–30% | Mean is approximate — only large regressions are detectable |
+| `[POOR >30%]` | > 30% | Mean is unreliable — you need more iterations |
+
+**CV (Coefficient of Variation)** — how consistent individual runs are, independent of the mean. Even with a precise mean (GOOD RME), a POOR CV means some runs are much slower than others. Investigate warmup, GC pauses, or I/O contention.
+
+| CV tag | Value | What it means |
+|---|---|---|
+| `[GOOD <0.1]` | < 0.1 | Very consistent — low run-to-run variance |
+| `[FAIR 0.1-0.3]` | 0.1–0.3 | Moderate variance — typical for I/O-bound code |
+| `[POOR >0.3]` | > 0.3 | High variance — runs differ by more than 30% of the mean |
+
+### Reading them together
+
+The interpretation line combines RME, CV, and CI into a single recommendation:
+
+| RME | CV | Interpretation |
+|-----|-----|----------------|
+| GOOD | GOOD | Precise and consistent — safe for regression detection |
+| GOOD | FAIR | Reliable — moderate run-to-run variance is expected |
+| GOOD | POOR | Precise mean but inconsistent runs — investigate noise sources |
+| FAIR | FAIR/GOOD | Usable for rough comparison — increase iterations for tighter estimates |
+| FAIR | POOR | Approximate mean + high variance — increase iterations and investigate noise |
+| POOR | any | Mean is not reliable — increase iterations, add warmup, or enable outlier removal |
+
+When a CI bound is provided, the interpretation also checks whether the confidence interval exceeds your threshold — telling you if the true mean might exceed your performance budget.
+
+**When you see `[POOR]` tags**, try these in order:
+
+1. **Increase iterations** — more data reduces RME and stabilizes the CI
+2. **Add warmup iterations** — exclude JIT and cache effects that inflate CV
+3. **Enable outlier removal** (`outliers: 'remove'`) — filter GC pauses that inflate CV
+4. **Widen your threshold** — accept that the code path has inherent variance
 
 ## Test stability / CI notes
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,131 @@
+import {Stats} from "./metrics";
+
+export type TagLabel = 'GOOD' | 'FAIR' | 'POOR';
+
+export interface Tag {
+    label: TagLabel;
+    range: string;
+}
+
+/** Format a classification tag for display: combines the label with its threshold range. */
+export function formatTag(tag: Tag): string {
+    return `${tag.label} ${tag.range}`;
+}
+
+/**
+ * Classify the Relative Margin of Error (RME = margin of error / |mean| * 100).
+ * RME quantifies how precise the mean estimate is — a lower RME means the mean
+ * is more tightly bounded and the confidence interval is narrower.
+ *
+ * Thresholds follow standard benchmarking practice:
+ * - <10%: the mean is precise enough to detect small regressions
+ * - 10-30%: the mean is approximate — useful for rough comparisons but not fine-grained detection
+ * - >30%: the confidence interval is so wide that the mean is not a reliable point estimate
+ */
+export function classifyRME(rme: number | null): Tag | null {
+    if (rme === null) return null;
+    if (rme < 10) return { label: 'GOOD', range: '<10%' };
+    if (rme <= 30) return { label: 'FAIR', range: '10-30%' };
+    return { label: 'POOR', range: '>30%' };
+}
+
+/**
+ * Classify the Coefficient of Variation (CV = stddev / |mean|).
+ * CV measures run-to-run consistency independent of the absolute timing.
+ *
+ * Thresholds:
+ * - <0.1: very consistent — noise is under 10% of the mean
+ * - 0.1-0.3: moderate variance — common for I/O-bound or GC-sensitive code
+ * - >0.3: high variance — individual runs differ by more than 30% of the mean,
+ *   suggesting external interference (GC, scheduling) or inherently variable code
+ */
+export function classifyCV(cv: number | null): Tag | null {
+    if (cv === null) return null;
+    if (cv < 0.1) return { label: 'GOOD', range: '<0.1' };
+    if (cv <= 0.3) return { label: 'FAIR', range: '0.1-0.3' };
+    return { label: 'POOR', range: '>0.3' };
+}
+
+/**
+ * Classify sample size adequacy for statistical analysis.
+ *
+ * Thresholds are based on confidence interval reliability:
+ * - <10: too few data points — confidence intervals are very wide and unstable
+ * - 10-30: usable but imprecise — Student's t-distribution is used (wider intervals)
+ * - >30: adequate — the z-distribution applies (CLT kicks in), intervals are stable
+ *
+ * The 30-sample boundary aligns with the classic rule of thumb for when the
+ * Central Limit Theorem provides a reliable normal approximation.
+ */
+export function classifySampleAdequacy(n: number): Tag {
+    if (n < 10) return { label: 'POOR', range: '<10' };
+    if (n <= 30) return { label: 'FAIR', range: '10-30' };
+    return { label: 'GOOD', range: '>30' };
+}
+
+/**
+ * Generate a human-readable interpretation of the benchmark results.
+ *
+ * Considers all three key metrics together:
+ * - RME: how precise the mean estimate is (determines if we can trust the average)
+ * - CV: how consistent individual runs are (determines if variance is a concern)
+ * - CI bounds vs a threshold: whether the confidence interval suggests the true mean exceeds the budget
+ *
+ * Branches on the RME × CV matrix (not raw numeric thresholds):
+ * | RME  | CV        | Outcome                                           |
+ * |------|-----------|---------------------------------------------------|
+ * | POOR | any       | Mean unreliable — need more data                  |
+ * | FAIR | POOR      | Approximate mean + high variance — double concern  |
+ * | FAIR | FAIR/GOOD | Approximate mean, acceptable variance              |
+ * | GOOD | POOR      | Precise mean but inconsistent runs — noise issue   |
+ * | GOOD | FAIR      | Reliable — moderate variance is expected            |
+ * | GOOD | GOOD      | Precise and consistent — safe for regression detection |
+ *
+ * When expectedDuration is provided, also checks if the CI upper bound
+ * exceeds the user's threshold — flagging a potential budget overrun even
+ * when the quantile assertion passes.
+ */
+export function generateInterpretation(stats: Stats, expectedDuration?: number): string {
+    const rme = classifyRME(stats.relativeMarginOfError);
+    const cv = classifyCV(stats.coefficientOfVariation);
+    const sample = classifySampleAdequacy(stats.n);
+    const remedy = 'try increasing iterations, adding warmup, or enabling outlier removal';
+
+    if (stats.confidenceInterval === null) {
+        return 'results are unreliable — insufficient data for statistical analysis. Add more iterations to enable confidence intervals';
+    }
+    if (rme === null) {
+        return 'relative error cannot be computed (mean ≈ 0) — RME and CV are unavailable when the mean is zero';
+    }
+
+    let message: string;
+
+    if (rme.label === 'POOR') {
+        const sampleNote = sample.label !== 'GOOD' ? ` with ${sample.label} sample size` : '';
+        message = `mean is not reliable (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)})${sampleNote}. ${remedy}`;
+    } else if (rme.label === 'FAIR' && cv!.label === 'POOR') {
+        message = `mean is approximate and variance is high (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}) — increase iterations and investigate noise sources (GC, I/O, scheduling)`;
+    } else if (rme.label === 'FAIR') {
+        message = `results are usable for rough comparison (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}) — increase iterations for tighter estimates`;
+    } else if (cv!.label === 'POOR') {
+        message = `mean is precise but individual runs vary widely (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}) — investigate noise sources (GC, I/O, scheduling)`;
+    } else if (cv!.label === 'FAIR') {
+        message = `results are reliable (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}) — moderate run-to-run variance is expected`;
+    } else {
+        message = `results are precise and consistent (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}) — safe for regression detection`;
+    }
+
+    if (expectedDuration !== undefined && stats.confidenceInterval !== null) {
+        const lower = stats.confidenceInterval[0];
+        const upper = stats.confidenceInterval[1];
+        if (lower > expectedDuration) {
+            message += `. CI range [${lower.toFixed(2)}, ${upper.toFixed(2)}]ms is entirely above your ${expectedDuration}ms threshold — the code is almost certainly too slow`;
+        } else if (upper > expectedDuration) {
+            message += `. CI upper bound (${upper.toFixed(2)}ms) exceeds your ${expectedDuration}ms threshold — the true mean likely exceeds your budget, consider optimizing the code or raising the threshold`;
+        } else {
+            message += `. CI range [${lower.toFixed(2)}, ${upper.toFixed(2)}]ms is within your ${expectedDuration}ms threshold — the mean is safely within budget`;
+        }
+    }
+
+    return message;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import {expect} from '@jest/globals';
 import {printReceived, printExpected} from 'jest-matcher-utils';
 import {calcQuantile, calcStats, removeOutliers, Stats} from "./metrics";
 import {calcShapeDiagnostics} from "./shape";
+import {classifyRME, classifyCV, classifySampleAdequacy, generateInterpretation, formatTag} from "./diagnostics";
 
 const nowInMillis = () => {
     const hrTime = process.hrtime();
@@ -147,12 +148,19 @@ function formatStatValue(value: number | null): string {
     return value === null ? 'N/A' : value.toFixed(2);
 }
 
-function formatStatsBlock(stats: Stats, durations: number[]): string {
+function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: number): string {
+    const rmeTag = classifyRME(stats.relativeMarginOfError);
+    const cvTag = classifyCV(stats.coefficientOfVariation);
+
     const ciText = stats.confidenceInterval === null
-        ? '95% CI: N/A (insufficient data)'
-        : `95% CI: [${stats.confidenceInterval[0].toFixed(2)}, ${stats.confidenceInterval[1].toFixed(2)}]ms`;
-    const rmeText = `RME: ${stats.relativeMarginOfError === null ? 'N/A' : stats.relativeMarginOfError.toFixed(2) + '%'}`;
-    const cvText = `CV: ${stats.coefficientOfVariation === null ? 'N/A' : stats.coefficientOfVariation.toFixed(2)}`;
+        ? 'Confidence Interval (CI): N/A (insufficient data)'
+        : `Confidence Interval (CI): 95% [${stats.confidenceInterval[0].toFixed(2)}, ${stats.confidenceInterval[1].toFixed(2)}]ms`;
+    const rmeText = stats.relativeMarginOfError === null
+        ? 'Relative Margin of Error (RME): N/A'
+        : `Relative Margin of Error (RME): ${stats.relativeMarginOfError.toFixed(2)}% [${formatTag(rmeTag!)}]`;
+    const cvText = stats.coefficientOfVariation === null
+        ? 'Coefficient of Variation (CV): N/A'
+        : `Coefficient of Variation (CV): ${stats.coefficientOfVariation.toFixed(2)} [${formatTag(cvTag!)}]`;
 
     const p25 = calcQuantile(25, durations);
     const p50 = stats.median;
@@ -164,9 +172,13 @@ function formatStatsBlock(stats: Stats, durations: number[]): string {
 
     const lines = [
         `Statistics (n=${stats.n}): mean=${formatStatValue(stats.mean)}ms, median=${formatStatValue(stats.median)}ms, stddev=${formatStatValue(stats.stddev)}ms`,
-        `${ciText} | ${rmeText} | ${cvText}`,
+        ciText,
+        rmeText,
+        cvText,
         `Distribution: min=${formatStatValue(stats.min)}ms | P25=${formatStatValue(p25)}ms | P50=${formatStatValue(p50)}ms | P75=${formatStatValue(p75)}ms | P90=${formatStatValue(p90)}ms | max=${formatStatValue(stats.max)}ms`,
         `Shape: ${shapeDiag.label} (skewness=${skewnessText}) | ${shapeDiag.sparkline}`,
+        `Sample adequacy: ${formatTag(classifySampleAdequacy(stats.n))} (n=${stats.n})`,
+        `Interpretation: ${generateInterpretation(stats, expectedDuration)}`,
     ];
 
     if (stats.warnings.length > 0) {
@@ -181,7 +193,7 @@ function formatStatsBlock(stats: Stats, durations: number[]): string {
 
 function assertDurationQuantile(iterations: number, quantile: number,  quantileValue: number, durations: number[], expectedDurationInMilliseconds: number) {
     const stats = calcStats(durations);
-    const statsBlock = formatStatsBlock(stats, durations);
+    const statsBlock = formatStatsBlock(stats, durations, expectedDurationInMilliseconds);
 
     if (quantileValue <= expectedDurationInMilliseconds) {
         return {

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,0 +1,383 @@
+import {
+    classifyRME, classifyCV, classifySampleAdequacy,
+    generateInterpretation, formatTag, Tag
+} from '../src/diagnostics';
+import {Stats} from '../src/metrics';
+
+describe("formatTag", () => {
+    test("should combine label and range into a display string", () => {
+        // GIVEN a tag with label and range
+        const givenTag: Tag = { label: 'GOOD', range: '<10%' };
+
+        // WHEN formatting the tag
+        const actualResult = formatTag(givenTag);
+
+        // THEN the output combines both parts
+        expect(actualResult).toBe(`${givenTag.label} ${givenTag.range}`);
+    });
+});
+
+describe("classifyRME", () => {
+    test("should return null when RME is null", () => {
+        // GIVEN a null RME value
+        const givenRME = null;
+
+        // WHEN classifying
+        const actualResult = classifyRME(givenRME);
+
+        // THEN the result is null
+        expect(actualResult).toBeNull();
+    });
+
+    test("should return GOOD when RME is below 10%", () => {
+        // GIVEN an RME below the GOOD threshold
+        const givenRME = 9.99;
+
+        // WHEN classifying
+        const actualResult = classifyRME(givenRME);
+
+        // THEN the label is GOOD with <10% range
+        expect(actualResult).toEqual({ label: 'GOOD', range: '<10%' });
+    });
+
+    test("should return FAIR when RME is exactly 10%", () => {
+        // GIVEN an RME at the FAIR boundary
+        const givenRME = 10;
+
+        // WHEN classifying
+        const actualResult = classifyRME(givenRME);
+
+        // THEN the label is FAIR
+        expect(actualResult!.label).toBe('FAIR');
+    });
+
+    test("should return FAIR when RME is 30%", () => {
+        // GIVEN an RME at the upper FAIR boundary
+        const givenRME = 30;
+
+        // WHEN classifying
+        const actualResult = classifyRME(givenRME);
+
+        // THEN the label is still FAIR (inclusive)
+        expect(actualResult).toEqual({ label: 'FAIR', range: '10-30%' });
+    });
+
+    test("should return POOR when RME exceeds 30%", () => {
+        // GIVEN an RME above the POOR threshold
+        const givenRME = 30.01;
+
+        // WHEN classifying
+        const actualResult = classifyRME(givenRME);
+
+        // THEN the label is POOR
+        expect(actualResult).toEqual({ label: 'POOR', range: '>30%' });
+    });
+});
+
+describe("classifyCV", () => {
+    test("should return null when CV is null", () => {
+        // GIVEN a null CV value
+        const givenCV = null;
+
+        // WHEN classifying
+        const actualResult = classifyCV(givenCV);
+
+        // THEN the result is null
+        expect(actualResult).toBeNull();
+    });
+
+    test("should return GOOD when CV is below 0.1", () => {
+        // GIVEN a CV below the GOOD threshold
+        const givenCV = 0.09;
+
+        // WHEN classifying
+        const actualResult = classifyCV(givenCV);
+
+        // THEN the label is GOOD
+        expect(actualResult).toEqual({ label: 'GOOD', range: '<0.1' });
+    });
+
+    test("should return FAIR when CV is exactly 0.1", () => {
+        // GIVEN a CV at the FAIR boundary
+        const givenCV = 0.1;
+
+        // WHEN classifying
+        const actualResult = classifyCV(givenCV);
+
+        // THEN the label is FAIR
+        expect(actualResult!.label).toBe('FAIR');
+    });
+
+    test("should return FAIR when CV is 0.3", () => {
+        // GIVEN a CV at the upper FAIR boundary
+        const givenCV = 0.3;
+
+        // WHEN classifying
+        const actualResult = classifyCV(givenCV);
+
+        // THEN the label is still FAIR (inclusive)
+        expect(actualResult).toEqual({ label: 'FAIR', range: '0.1-0.3' });
+    });
+
+    test("should return POOR when CV exceeds 0.3", () => {
+        // GIVEN a CV above the POOR threshold
+        const givenCV = 0.31;
+
+        // WHEN classifying
+        const actualResult = classifyCV(givenCV);
+
+        // THEN the label is POOR
+        expect(actualResult).toEqual({ label: 'POOR', range: '>0.3' });
+    });
+});
+
+describe("classifySampleAdequacy", () => {
+    test("should return POOR when n is below 10", () => {
+        // GIVEN a sample size below the POOR threshold
+        const givenN = 5;
+
+        // WHEN classifying
+        const actualResult = classifySampleAdequacy(givenN);
+
+        // THEN the label is POOR
+        expect(actualResult).toEqual({ label: 'POOR', range: '<10' });
+    });
+
+    test("should return FAIR when n is exactly 10", () => {
+        // GIVEN a sample size at the FAIR boundary
+        const givenN = 10;
+
+        // WHEN classifying
+        const actualResult = classifySampleAdequacy(givenN);
+
+        // THEN the label is FAIR
+        expect(actualResult).toEqual({ label: 'FAIR', range: '10-30' });
+    });
+
+    test("should return FAIR when n is 30", () => {
+        // GIVEN a sample size at the upper FAIR boundary
+        const givenN = 30;
+
+        // WHEN classifying
+        const actualResult = classifySampleAdequacy(givenN);
+
+        // THEN the label is still FAIR (inclusive)
+        expect(actualResult).toEqual({ label: 'FAIR', range: '10-30' });
+    });
+
+    test("should return GOOD when n exceeds 30", () => {
+        // GIVEN a sample size above the GOOD threshold
+        const givenN = 31;
+
+        // WHEN classifying
+        const actualResult = classifySampleAdequacy(givenN);
+
+        // THEN the label is GOOD
+        expect(actualResult).toEqual({ label: 'GOOD', range: '>30' });
+    });
+});
+
+describe("generateInterpretation", () => {
+    function buildStats(overrides: Partial<Stats>): Stats {
+        return {
+            n: 31, min: 1, max: 10, mean: 5, median: 5, stddev: 1,
+            marginOfError: 0.35, relativeMarginOfError: 7.0,
+            confidenceInterval: [4.65, 5.35],
+            coefficientOfVariation: 0.05, skewness: 0, isSmallSample: false,
+            confidenceMethod: 'z', confidenceCriticalValue: 1.96, warnings: [],
+            ...overrides,
+        };
+    }
+
+    test("should return unreliable when CI is null (insufficient data)", () => {
+        // GIVEN stats with null confidence interval (n=1 scenario)
+        const givenStats = buildStats({
+            n: 1, confidenceInterval: null, stddev: null,
+            marginOfError: null, relativeMarginOfError: null,
+            coefficientOfVariation: null, confidenceMethod: null,
+            confidenceCriticalValue: null, isSmallSample: true,
+        });
+
+        // WHEN generating interpretation
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN it says results are unreliable
+        expect(actualResult).toContain('results are unreliable');
+        expect(actualResult).toContain('Add more iterations');
+    });
+
+    test("should return mean≈0 message when RME is null but CI exists", () => {
+        // GIVEN stats with null RME (mean=0 scenario) but valid CI
+        const givenStats = buildStats({
+            mean: 0, relativeMarginOfError: null, coefficientOfVariation: null,
+        });
+
+        // WHEN generating interpretation
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN it explains the mean≈0 limitation
+        expect(actualResult).toContain('relative error cannot be computed');
+        expect(actualResult).toContain('mean is zero');
+    });
+
+    test("should return precise+consistent when RME is GOOD and CV is GOOD", () => {
+        // GIVEN stats with GOOD RME and GOOD CV
+        const givenRME = 5.0;
+        const givenCV = 0.05;
+        const givenStats = buildStats({
+            relativeMarginOfError: givenRME, coefficientOfVariation: givenCV,
+        });
+
+        // WHEN generating interpretation
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN it confirms safe for regression detection
+        expect(actualResult).toContain('precise and consistent');
+        expect(actualResult).toContain('safe for regression detection');
+    });
+
+    test("should return reliable when RME is GOOD and CV is FAIR", () => {
+        // GIVEN stats with GOOD RME and FAIR CV
+        const givenRME = 5.0;
+        const givenCV = 0.2;
+        const givenStats = buildStats({
+            relativeMarginOfError: givenRME, coefficientOfVariation: givenCV,
+        });
+
+        // WHEN generating interpretation
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN it says reliable with expected moderate variance
+        expect(actualResult).toContain('results are reliable');
+        expect(actualResult).toContain('moderate run-to-run variance');
+    });
+
+    test("should flag inconsistent runs when RME is GOOD and CV is POOR", () => {
+        // GIVEN stats with GOOD RME and POOR CV
+        const givenRME = 5.0;
+        const givenCV = 0.5;
+        const givenStats = buildStats({
+            relativeMarginOfError: givenRME, coefficientOfVariation: givenCV,
+        });
+
+        // WHEN generating interpretation
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN it warns about inconsistent individual runs
+        expect(actualResult).toContain('precise but individual runs vary widely');
+        expect(actualResult).toContain('investigate noise sources');
+    });
+
+    test("should return rough comparison when RME is FAIR and CV is FAIR", () => {
+        // GIVEN stats with FAIR RME and FAIR CV
+        const givenRME = 15.0;
+        const givenCV = 0.2;
+        const givenStats = buildStats({
+            relativeMarginOfError: givenRME, coefficientOfVariation: givenCV,
+        });
+
+        // WHEN generating interpretation
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN it suggests increasing iterations
+        expect(actualResult).toContain('usable for rough comparison');
+        expect(actualResult).toContain('increase iterations');
+    });
+
+    test("should flag double concern when RME is FAIR and CV is POOR", () => {
+        // GIVEN stats with FAIR RME and POOR CV
+        const givenRME = 15.0;
+        const givenCV = 0.5;
+        const givenStats = buildStats({
+            relativeMarginOfError: givenRME, coefficientOfVariation: givenCV,
+        });
+
+        // WHEN generating interpretation
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN it flags both approximate mean and high variance
+        expect(actualResult).toContain('approximate and variance is high');
+        expect(actualResult).toContain('investigate noise sources');
+    });
+
+    test("should return not reliable with sample note when RME is POOR and sample is inadequate", () => {
+        // GIVEN stats with POOR RME and small sample
+        const givenRME = 40.0;
+        const givenCV = 0.5;
+        const givenN = 5;
+        const givenStats = buildStats({
+            n: givenN, relativeMarginOfError: givenRME, coefficientOfVariation: givenCV,
+            isSmallSample: true,
+        });
+
+        // WHEN generating interpretation
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN it mentions unreliable mean, sample size, and remediation
+        expect(actualResult).toContain('mean is not reliable');
+        expect(actualResult).toContain(`${classifySampleAdequacy(givenN).label} sample size`);
+        expect(actualResult).toContain('try increasing iterations');
+    });
+
+    test("should return not reliable without sample note when RME is POOR and sample is adequate", () => {
+        // GIVEN stats with POOR RME but adequate sample
+        const givenRME = 40.0;
+        const givenCV = 0.5;
+        const givenStats = buildStats({
+            relativeMarginOfError: givenRME, coefficientOfVariation: givenCV,
+        });
+
+        // WHEN generating interpretation
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN it mentions unreliable mean and remediation but not sample size
+        expect(actualResult).toContain('mean is not reliable');
+        expect(actualResult).toContain('try increasing iterations');
+        expect(actualResult).not.toContain('sample size');
+    });
+
+    test("should append CI-within-budget note when CI upper bound is below threshold", () => {
+        // GIVEN stats with CI and a threshold well above the upper bound
+        const givenCI: [number, number] = [4.65, 5.35];
+        const givenStats = buildStats({ confidenceInterval: givenCI });
+        const givenThreshold = 10;
+
+        // WHEN generating interpretation with threshold
+        const actualResult = generateInterpretation(givenStats, givenThreshold);
+
+        // THEN it confirms the CI is within budget
+        const expectedLowerBound = givenCI[0].toFixed(2);
+        const expectedUpperBound = givenCI[1].toFixed(2);
+        expect(actualResult).toContain(`CI range [${expectedLowerBound}, ${expectedUpperBound}]ms is within your ${givenThreshold}ms threshold`);
+        expect(actualResult).toContain('safely within budget');
+    });
+
+    test("should append CI-exceeds note when upper bound exceeds threshold but lower is within", () => {
+        // GIVEN stats with CI where lower < threshold < upper
+        const givenCI: [number, number] = [4.0, 12.0];
+        const givenStats = buildStats({ confidenceInterval: givenCI });
+        const givenThreshold = 10;
+
+        // WHEN generating interpretation with threshold
+        const actualResult = generateInterpretation(givenStats, givenThreshold);
+
+        // THEN it warns the upper bound exceeds budget
+        const expectedUpperBound = givenCI[1].toFixed(2);
+        expect(actualResult).toContain(`CI upper bound (${expectedUpperBound}ms) exceeds your ${givenThreshold}ms threshold`);
+        expect(actualResult).toContain('consider optimizing');
+    });
+
+    test("should append CI-entirely-above note when lower bound exceeds threshold", () => {
+        // GIVEN stats with CI entirely above the threshold
+        const givenCI: [number, number] = [15.0, 25.0];
+        const givenStats = buildStats({ confidenceInterval: givenCI });
+        const givenThreshold = 10;
+
+        // WHEN generating interpretation with threshold
+        const actualResult = generateInterpretation(givenStats, givenThreshold);
+
+        // THEN it flags the code as almost certainly too slow
+        expect(actualResult).toContain(`entirely above your ${givenThreshold}ms threshold`);
+        expect(actualResult).toContain('almost certainly too slow');
+    });
+});

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,6 +1,7 @@
 import '../src/main';
 import * as metrics from '../src/metrics';
 import {calcShapeDiagnostics} from '../src/shape';
+import {classifyRME, classifyCV, classifySampleAdequacy, generateInterpretation, formatTag} from '../src/diagnostics';
 import {printExpected, printReceived} from "jest-matcher-utils";
 
 
@@ -8,15 +9,22 @@ function mockFunctionProcessTime(milliseconds: number) {
     mockFunctionProcessTimes([milliseconds]);
 }
 
-function buildStatsBlock(durations: number[]): string {
+function buildStatsBlock(durations: number[], expectedDuration?: number): string {
     const stats = metrics.calcStats(durations);
     const fmt = (v: number | null) => v !== null ? v.toFixed(2) : 'N/A';
 
+    const rmeTag = classifyRME(stats.relativeMarginOfError);
+    const cvTag = classifyCV(stats.coefficientOfVariation);
+
     const ciText = stats.confidenceInterval === null
-        ? '95% CI: N/A (insufficient data)'
-        : `95% CI: [${stats.confidenceInterval[0].toFixed(2)}, ${stats.confidenceInterval[1].toFixed(2)}]ms`;
-    const rmeText = `RME: ${stats.relativeMarginOfError === null ? 'N/A' : stats.relativeMarginOfError.toFixed(2) + '%'}`;
-    const cvText = `CV: ${stats.coefficientOfVariation === null ? 'N/A' : stats.coefficientOfVariation.toFixed(2)}`;
+        ? 'Confidence Interval (CI): N/A (insufficient data)'
+        : `Confidence Interval (CI): 95% [${stats.confidenceInterval[0].toFixed(2)}, ${stats.confidenceInterval[1].toFixed(2)}]ms`;
+    const rmeText = stats.relativeMarginOfError === null
+        ? 'Relative Margin of Error (RME): N/A'
+        : `Relative Margin of Error (RME): ${stats.relativeMarginOfError.toFixed(2)}% [${formatTag(rmeTag!)}]`;
+    const cvText = stats.coefficientOfVariation === null
+        ? 'Coefficient of Variation (CV): N/A'
+        : `Coefficient of Variation (CV): ${stats.coefficientOfVariation.toFixed(2)} [${formatTag(cvTag!)}]`;
 
     const p25 = metrics.calcQuantile(25, durations);
     const p50 = stats.median;
@@ -28,9 +36,13 @@ function buildStatsBlock(durations: number[]): string {
 
     const lines = [
         `Statistics (n=${stats.n}): mean=${fmt(stats.mean)}ms, median=${fmt(stats.median)}ms, stddev=${fmt(stats.stddev)}ms`,
-        `${ciText} | ${rmeText} | ${cvText}`,
+        ciText,
+        rmeText,
+        cvText,
         `Distribution: min=${fmt(stats.min)}ms | P25=${fmt(p25)}ms | P50=${fmt(p50)}ms | P75=${fmt(p75)}ms | P90=${fmt(p90)}ms | max=${fmt(stats.max)}ms`,
         `Shape: ${shapeDiag.label} (skewness=${skewnessText}) | ${shapeDiag.sparkline}`,
+        `Sample adequacy: ${formatTag(classifySampleAdequacy(stats.n))} (n=${stats.n})`,
+        `Interpretation: ${generateInterpretation(stats, expectedDuration)}`,
     ];
 
     if (stats.warnings.length > 0) {
@@ -209,7 +221,7 @@ describe("Test jest expect.toCompleteWithinQuantile assertion", () => {
         // WHEN asserting that (Q%) of the times when running for (I) iterations, the function will complete in (T) - 1 milliseconds
         // THEN expect to fail
         const Q = 1;
-        const expectedStatsBlock = buildStatsBlock(T_Array);
+        const expectedStatsBlock = buildStatsBlock(T_Array, T - 1);
 
         expect(() => {
             expect(() => undefined).toCompleteWithinQuantile(T - 1, {iterations: I, quantile: Q});
@@ -223,7 +235,7 @@ describe("Test jest expect.toCompleteWithinQuantile assertion", () => {
 
         // WHEN asserting with iterations=1 and it fails
         // THEN the stats block should show N/A for stddev (n=1 cannot compute stddev)
-        const expectedStatsBlock = buildStatsBlock([T]);
+        const expectedStatsBlock = buildStatsBlock([T], T - 1);
         expect(expectedStatsBlock).toContain("stddev=N/A");
 
         expect(() => {
@@ -241,7 +253,7 @@ describe("Test jest expect.toCompleteWithinQuantile assertion", () => {
         // WHEN asserting that (Q%) of the times when running for (I) iterations, the function will complete in (T) milliseconds
         // THEN expect to fail
         const Q = 1;
-        const expectedStatsBlock = buildStatsBlock(T_Array);
+        const expectedStatsBlock = buildStatsBlock(T_Array, T);
 
         expect(() => {
             expect(() => undefined).not.toCompleteWithinQuantile(T, {iterations: I, quantile: Q});
@@ -343,7 +355,7 @@ describe("Test jest expect.toCompleteWithinQuantile assertion", () => {
         }
 
         // THEN the message should indicate CI is unavailable
-        expect(errorMessage).toContain('95% CI: N/A (insufficient data)');
+        expect(errorMessage).toContain('Confidence Interval (CI): N/A (insufficient data)');
         // AND warnings should be present
         expect(errorMessage).toContain('Warnings:');
         expect(errorMessage).toContain('Single data point: standard deviation and confidence interval cannot be computed');
@@ -429,8 +441,8 @@ describe("Test jest expect.toCompleteWithinQuantile assertion", () => {
         }
 
         // THEN RME and CV should show N/A
-        expect(errorMessage).toContain('RME: N/A');
-        expect(errorMessage).toContain('CV: N/A');
+        expect(errorMessage).toContain('Relative Margin of Error (RME): N/A');
+        expect(errorMessage).toContain('Coefficient of Variation (CV): N/A');
     });
 
     test("Should show Shape line in failure message", () => {
@@ -513,6 +525,353 @@ describe("Test jest expect.toCompleteWithinQuantile assertion", () => {
         expect(errorMessage).toContain('Shape: right-skewed');
         expect(errorMessage).toContain('skewness=');
     });
+
+    test("README example: realistic API latency P95 at 10ms budget (n=50)", () => {
+        // GIVEN realistic right-skewed API latency durations (same data as above)
+        const givenDurations = [15.75,4.44,13.11,7.87,13.56,5.89,5.67,15.54,21.76,3.34,8.35,7.41,10.11,21.03,5.05,4.16,7.01,6.7,4.64,4.51,13.53,3.14,41.15,20.43,9.87,3.86,4.2,5.5,3.48,7.92,3.63,3.09,4.25,5,3.74,3.17,4.61,3.21,20.4,2.04,3.17,5.05,12.82,9.98,4.44,5.74,5.02,7.24,11.99,23.17];
+        const givenThreshold = 10;
+        const givenQuantile = 95;
+        mockFunctionProcessTimes(givenDurations);
+
+        // WHEN asserting P95 should be within 10ms budget and it fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(givenThreshold, {iterations: givenDurations.length, quantile: givenQuantile});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the output is a realistic failure diagnostic
+        // eslint-disable-next-line no-console
+        console.log(`\n--- README example (P${givenQuantile} at ${givenThreshold}ms, n=${givenDurations.length}) ---\n${actualMessage}\n`);
+        expect(actualMessage).toContain(`expected that ${givenQuantile}% of the time`);
+        expect(actualMessage).toContain('Confidence Interval (CI):');
+        expect(actualMessage).toContain('Relative Margin of Error (RME):');
+        expect(actualMessage).toContain('Coefficient of Variation (CV):');
+        expect(actualMessage).toContain('Sample adequacy:');
+        expect(actualMessage).toContain('Interpretation:');
+    });
+});
+
+describe("Benchmark log interpretability annotations", () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    function getFailureMessage(durations: number[]): string {
+        mockFunctionProcessTimes(durations);
+        let errorMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(0.001, {iterations: durations.length, quantile: 1});
+        } catch (e) {
+            errorMessage = (e as Error).message;
+        }
+        return errorMessage;
+    }
+
+    test("should interpret as precise and consistent when RME is GOOD and CV is GOOD", () => {
+        // GIVEN 31 identical durations producing GOOD RME and GOOD CV
+        const givenDurations = Array(31).fill(10);
+
+        // WHEN the quantile matcher fails
+        const actualMessage = getFailureMessage(givenDurations);
+
+        // THEN the output shows GOOD tags and safe-for-regression interpretation
+        const expectedSampleTag = formatTag(classifySampleAdequacy(givenDurations.length));
+        expect(actualMessage).toContain('[GOOD <10%]');
+        expect(actualMessage).toContain(`Sample adequacy: ${expectedSampleTag} (n=${givenDurations.length})`);
+        expect(actualMessage).toContain('Interpretation: results are precise and consistent (RME: GOOD <10%');
+        expect(actualMessage).toContain('safe for regression detection');
+    });
+
+    test("should interpret as rough comparison when RME is FAIR and CV is FAIR", () => {
+        // GIVEN durations with mocked FAIR RME (15%) and FAIR CV (0.2)
+        const givenDurations = [8, 9, 10, 11, 12];
+        mockFunctionProcessTimes(givenDurations);
+
+        const givenStats = metrics.calcStats(givenDurations);
+        jest.spyOn(metrics, 'calcStats').mockReturnValue({
+            ...givenStats,
+            relativeMarginOfError: 15.0,
+            coefficientOfVariation: 0.2,
+        });
+
+        // WHEN the quantile matcher fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(0.001, {iterations: givenDurations.length, quantile: 1});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the output shows FAIR tags and rough-comparison interpretation
+        const expectedSampleTag = formatTag(classifySampleAdequacy(givenDurations.length));
+        expect(actualMessage).toContain('Relative Margin of Error (RME): 15.00% [FAIR 10-30%]');
+        expect(actualMessage).toContain('Coefficient of Variation (CV): 0.20 [FAIR 0.1-0.3]');
+        expect(actualMessage).toContain(`Sample adequacy: ${expectedSampleTag} (n=${givenDurations.length})`);
+        expect(actualMessage).toContain('Interpretation: results are usable for rough comparison (RME: FAIR 10-30%, CV: FAIR 0.1-0.3)');
+    });
+
+    test("should interpret as approximate with high variance when RME is FAIR and CV is POOR", () => {
+        // GIVEN durations with mocked FAIR RME (15%) and POOR CV (0.5)
+        const givenDurations = [8, 9, 10, 11, 12];
+        mockFunctionProcessTimes(givenDurations);
+
+        const givenStats = metrics.calcStats(givenDurations);
+        jest.spyOn(metrics, 'calcStats').mockReturnValue({
+            ...givenStats,
+            relativeMarginOfError: 15.0,
+            coefficientOfVariation: 0.5,
+        });
+
+        // WHEN the quantile matcher fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(0.001, {iterations: givenDurations.length, quantile: 1});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the interpretation flags both approximate mean and high variance
+        expect(actualMessage).toContain('Interpretation: mean is approximate and variance is high (RME: FAIR 10-30%, CV: POOR >0.3)');
+        expect(actualMessage).toContain('investigate noise sources');
+    });
+
+    test("should interpret as precise but inconsistent when RME is GOOD and CV is POOR", () => {
+        // GIVEN 31 durations with mocked GOOD RME (5%) and POOR CV (0.5)
+        const givenDurations = Array(31).fill(10);
+        mockFunctionProcessTimes(givenDurations);
+
+        const givenStats = metrics.calcStats(givenDurations);
+        jest.spyOn(metrics, 'calcStats').mockReturnValue({
+            ...givenStats,
+            relativeMarginOfError: 5.0,
+            coefficientOfVariation: 0.5,
+        });
+
+        // WHEN the quantile matcher fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(0.001, {iterations: givenDurations.length, quantile: 1});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the interpretation flags inconsistent runs despite precise mean
+        expect(actualMessage).toContain('Interpretation: mean is precise but individual runs vary widely (RME: GOOD <10%, CV: POOR >0.3)');
+        expect(actualMessage).toContain('investigate noise sources');
+    });
+
+    test("should interpret as reliable when RME is GOOD and CV is FAIR", () => {
+        // GIVEN 31 durations with mocked GOOD RME (5%) and FAIR CV (0.2)
+        const givenDurations = Array(31).fill(10);
+        mockFunctionProcessTimes(givenDurations);
+
+        const givenStats = metrics.calcStats(givenDurations);
+        jest.spyOn(metrics, 'calcStats').mockReturnValue({
+            ...givenStats,
+            relativeMarginOfError: 5.0,
+            coefficientOfVariation: 0.2,
+        });
+
+        // WHEN the quantile matcher fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(0.001, {iterations: givenDurations.length, quantile: 1});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the interpretation confirms reliability with expected moderate variance
+        expect(actualMessage).toContain('Interpretation: results are reliable (RME: GOOD <10%, CV: FAIR 0.1-0.3)');
+        expect(actualMessage).toContain('moderate run-to-run variance is expected');
+    });
+
+    test("should include sample size note when RME is POOR and sample is inadequate", () => {
+        // GIVEN 5 high-variance durations producing POOR RME and POOR sample adequacy
+        const givenDurations = [5, 10, 15, 20, 25];
+
+        // WHEN the quantile matcher fails
+        const actualMessage = getFailureMessage(givenDurations);
+
+        // THEN the interpretation mentions POOR sample size and remediation
+        const expectedSampleTag = formatTag(classifySampleAdequacy(givenDurations.length));
+        expect(actualMessage).toContain('[POOR >30%]');
+        expect(actualMessage).toContain(`Sample adequacy: ${expectedSampleTag} (n=${givenDurations.length})`);
+        expect(actualMessage).toContain('Interpretation: mean is not reliable (RME: POOR >30%, CV:');
+        expect(actualMessage).toContain('POOR sample size');
+        expect(actualMessage).toContain('try increasing iterations');
+    });
+
+    test("should not include sample size note when RME is POOR but sample is adequate", () => {
+        // GIVEN 31 durations with mocked POOR RME (40%) and POOR CV (0.5)
+        const givenDurations = Array(31).fill(10);
+        mockFunctionProcessTimes(givenDurations);
+
+        const givenStats = metrics.calcStats(givenDurations);
+        jest.spyOn(metrics, 'calcStats').mockReturnValue({
+            ...givenStats,
+            relativeMarginOfError: 40.0,
+            coefficientOfVariation: 0.5,
+            isSmallSample: false,
+        });
+
+        // WHEN the quantile matcher fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(0.001, {iterations: givenDurations.length, quantile: 1});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the interpretation omits sample size note for adequate samples
+        const expectedSampleTag = formatTag(classifySampleAdequacy(givenDurations.length));
+        expect(actualMessage).toContain('[POOR >30%]');
+        expect(actualMessage).toContain(`Sample adequacy: ${expectedSampleTag} (n=${givenDurations.length})`);
+        expect(actualMessage).toContain('Interpretation: mean is not reliable (RME: POOR >30%, CV: POOR >0.3)');
+        expect(actualMessage).toContain('try increasing iterations');
+        expect(actualMessage).not.toContain('sample size');
+    });
+
+    test("should note CI upper bound exceeds threshold when lower bound is within budget", () => {
+        // GIVEN durations with mocked CI [5.0, 15.0] and a threshold of 8ms
+        const givenDurations = [8, 9, 10, 11, 12];
+        mockFunctionProcessTimes(givenDurations);
+
+        const givenCILower = 5.0;
+        const givenCIUpper = 15.0;
+        const givenStats = metrics.calcStats(givenDurations);
+        jest.spyOn(metrics, 'calcStats').mockReturnValue({
+            ...givenStats,
+            confidenceInterval: [givenCILower, givenCIUpper] as [number, number],
+            relativeMarginOfError: 50.0,
+            coefficientOfVariation: 0.5,
+        });
+        const givenThreshold = 8;
+
+        // WHEN the quantile matcher fails (Q1=8.04 > 8ms)
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(givenThreshold, {iterations: givenDurations.length, quantile: 1});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the interpretation notes the CI upper bound exceeds the budget
+        const expectedUpperBound = givenCIUpper.toFixed(2);
+        expect(actualMessage).toContain(`CI upper bound (${expectedUpperBound}ms) exceeds your ${givenThreshold}ms threshold`);
+        expect(actualMessage).toContain('consider optimizing the code or raising the threshold');
+    });
+
+    test("should note CI is safely within budget when upper bound is below threshold", () => {
+        // GIVEN 31 identical durations (mean=10, CI≈[10,10]) and a generous threshold of 100ms
+        const givenDurations = Array(31).fill(10);
+        mockFunctionProcessTimes(givenDurations);
+        const givenThreshold = 100;
+
+        // WHEN the .not quantile matcher fails (quantile <= threshold, so .not throws)
+        let actualMessage = '';
+        try {
+            expect(() => undefined).not.toCompleteWithinQuantile(givenThreshold, {iterations: givenDurations.length, quantile: 1});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the interpretation confirms the CI is within budget
+        expect(actualMessage).toContain('safely within budget');
+    });
+
+    test("should note CI is entirely above threshold when lower bound exceeds budget", () => {
+        // GIVEN durations with mean≈102 and a threshold of 1ms
+        const givenDurations = [100, 101, 102, 103, 104];
+        mockFunctionProcessTimes(givenDurations);
+        const givenThreshold = 1;
+
+        // WHEN the quantile matcher fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(givenThreshold, {iterations: givenDurations.length, quantile: 1});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the interpretation flags the code as almost certainly too slow
+        expect(actualMessage).toContain(`entirely above your ${givenThreshold}ms threshold`);
+        expect(actualMessage).toContain('almost certainly too slow');
+    });
+
+    test("should show no tags when CI is null (n=1)", () => {
+        // GIVEN a single duration producing null CI, RME, and CV
+        const givenDurations = [10];
+
+        // WHEN the quantile matcher fails
+        const actualMessage = getFailureMessage(givenDurations);
+
+        // THEN no classification tags appear and interpretation says unreliable
+        expect(actualMessage).toContain('Confidence Interval (CI): N/A (insufficient data)');
+        expect(actualMessage).not.toContain('[GOOD');
+        expect(actualMessage).not.toContain('[FAIR');
+        expect(actualMessage).not.toContain('[POOR');
+        expect(actualMessage).toContain('Relative Margin of Error (RME): N/A');
+        expect(actualMessage).toContain('Coefficient of Variation (CV): N/A');
+        const expectedSampleTag = formatTag(classifySampleAdequacy(givenDurations.length));
+        expect(actualMessage).toContain(`Sample adequacy: ${expectedSampleTag} (n=${givenDurations.length})`);
+        expect(actualMessage).toContain('Interpretation: results are unreliable');
+    });
+
+    test("should show FAIR sample adequacy when n=10", () => {
+        // GIVEN 10 identical durations
+        const givenDurations = Array(10).fill(10);
+
+        // WHEN the quantile matcher fails
+        const actualMessage = getFailureMessage(givenDurations);
+
+        // THEN sample adequacy is FAIR
+        const expectedSampleTag = formatTag(classifySampleAdequacy(givenDurations.length));
+        expect(actualMessage).toContain(`Sample adequacy: ${expectedSampleTag} (n=${givenDurations.length})`);
+    });
+
+    test("should show FAIR sample adequacy when n=30", () => {
+        // GIVEN 30 identical durations
+        const givenDurations = Array(30).fill(10);
+
+        // WHEN the quantile matcher fails
+        const actualMessage = getFailureMessage(givenDurations);
+
+        // THEN sample adequacy is FAIR
+        const expectedSampleTag = formatTag(classifySampleAdequacy(givenDurations.length));
+        expect(actualMessage).toContain(`Sample adequacy: ${expectedSampleTag} (n=${givenDurations.length})`);
+    });
+
+    test("should show no RME/CV tags when RME is null but CI exists (mean=0)", () => {
+        // GIVEN durations with mocked mean=0 (produces null RME and CV but non-null CI)
+        const givenDurations = [8, 9, 10, 11, 12];
+        mockFunctionProcessTimes(givenDurations);
+
+        const givenStats = metrics.calcStats(givenDurations);
+        jest.spyOn(metrics, 'calcStats').mockReturnValue({
+            ...givenStats,
+            mean: 0,
+            relativeMarginOfError: null,
+            coefficientOfVariation: null,
+            confidenceInterval: [givenStats.confidenceInterval![0], givenStats.confidenceInterval![1]],
+        });
+
+        // WHEN the quantile matcher fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(0.001, {iterations: givenDurations.length, quantile: 1});
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN CI exists but has no tag, and interpretation explains mean≈0 limitation
+        expect(actualMessage).toContain('Confidence Interval (CI): 95% [');
+        expect(actualMessage).not.toMatch(/Confidence Interval \(CI\): 95% \[.*]ms \[/);
+        expect(actualMessage).toContain('Relative Margin of Error (RME): N/A');
+        expect(actualMessage).toContain('Coefficient of Variation (CV): N/A');
+        expect(actualMessage).toContain('Interpretation: relative error cannot be computed');
+    });
 });
 
 describe("Test jest expect.toResolveWithinQuantile assertion", () => {
@@ -554,7 +913,7 @@ describe("Test jest expect.toResolveWithinQuantile assertion", () => {
         // WHEN asserting that (Q%) of the times when running for (I) iterations, the promise will resolve in (T) - 1 milliseconds
         // THEN expect to fail
         const Q = 1;
-        const expectedStatsBlock = buildStatsBlock(T_Array);
+        const expectedStatsBlock = buildStatsBlock(T_Array, T - 1);
         await expect(async () => {
             await expect(() => Promise.resolve()).toResolveWithinQuantile(T - 1, {iterations: I, quantile: Q});
         }).rejects.toThrowError(`expected that ${Q}% of the time when running ${I} iterations,\nthe function duration to be less or equal to ${printExpected(T - 1)} (ms),\ninstead it was ${printReceived(T)} (ms)\n\n${expectedStatsBlock}`);
@@ -570,7 +929,7 @@ describe("Test jest expect.toResolveWithinQuantile assertion", () => {
         // WHEN asserting that (Q%) of the times when running for (I) iterations, the promise will not resolve in (T) milliseconds
         // THEN expect to fail
         const Q = 1;
-        const expectedStatsBlock = buildStatsBlock(T_Array);
+        const expectedStatsBlock = buildStatsBlock(T_Array, T);
         await expect(async () => {
             await expect(() => Promise.resolve()).not.toResolveWithinQuantile(T, {iterations: I, quantile: Q});
         }).rejects.toThrowError(`expected that ${Q}% of the time when running ${I} iterations,\nthe function duration to be greater than ${printExpected(T)} (ms),\ninstead it was ${printReceived(T)} (ms)\n\n${expectedStatsBlock}`);


### PR DESCRIPTION
## Summary
- New `src/diagnostics.ts` module: structured Tag type, classifyRME, classifyCV, classifySampleAdequacy, generateInterpretation with JSDoc
- Each metric on its own line with full name: Confidence Interval (CI), Relative Margin of Error (RME), Coefficient of Variation (CV)
- Tags include threshold values (e.g. `[FAIR 10-30%]`)
- Interpretation line uses RME × CV matrix (6 outcomes) with CI bounds vs threshold comparison
- CI bounds compared against user's threshold with plain-language guidance
- README updated with realistic P95 example from actual test, "How to use each metric" section, RME × CV table

Closes #50

## Test plan
- [x] 214 tests pass, 100% statement + branch coverage
- [x] New `test/diagnostics.test.ts` with 27 direct unit tests
- [x] 13 integration tests for full output format
- [x] All tests follow GWT pattern
- [x] Zero lint errors, clean build
- [x] README example validated against actual test output