### PR TITLE
ci: upgrade SonarCloud action from v5 to v6

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,7 @@ jobs:
     - run: npm run build
     - run: npm test
     - name: SonarCloud Scan
-      uses: SonarSource/sonarqube-scan-action@v5
+      uses: SonarSource/sonarqube-scan-action@v6
       env:
         #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

- Upgrades `SonarSource/sonarqube-scan-action` from v5 to v6 to resolve the security vulnerability warning on every CI build

Closes #61

## Test plan

- [ ] CI build passes without the SonarCloud vulnerability warning
- [ ] SonarCloud scan completes successfully