### PR TITLE
docs: replace README banner with sparkline-style right-skewed distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,9 @@
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ApostolosBenisis_jest-performance-matchers&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=ApostolosBenisis_jest-performance-matchers)
 
 ```
-                ┌───┐
-             ┌──┤   ├──┐
-             │  │   │  │
-          ┌──┤  │   │  ├──┐
-          │  │  │   │  │  ├──┐
-       ┌──┤  │  │   │  │  │  ├──┐
-       │  │  │  │   │  │  │  │  ├──┐
-    ┌──┤  │  │  │   │  │  │  │  │  ├────┐
-────┴──┴──┴──┴──┴───┴──┴──┴──┴──┴──┴────┴───────
-         jest-performance-matchers
-         Assert · Measure · Prove
+   ▂▅▇█▇▅▄▃▂▂▁▁▁
+   jest-performance-matchers
+   Assert · Measure · Prove
 ```
 
 Jest matchers for **statistically reliable** performance testing in Node.js. Measure code execution time over multiple iterations, assert on quantiles, and catch performance regressions in CI — all with zero dependencies.


### PR DESCRIPTION
## Summary
- Replaces the 9-line box-drawing histogram banner with a compact 3-line sparkline
- Uses the same Unicode block characters (`▁▂▃▄▅▆▇█`) as `shape.ts`
- Distribution is right-skewed (peak left of center, long right tail)

Closes #52

## Test plan
- [x] Banner renders correctly on GitHub
- [x] No code changes — README only