### PR TITLE
feat: add setup/teardown options to all matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ expect(() => {
 
 ## Matchers
 
-### `.toCompleteWithin(ms)`
+### `.toCompleteWithin(ms, options?)`
 
 Assert that synchronous code runs within the given duration:
 
@@ -131,6 +131,13 @@ expect(() => {
 expect(() => {
     heavyComputation();
 }).not.toCompleteWithin(10);
+
+// With setup/teardown — setup return value is passed to the callback, not timed
+expect((data: number[]) => {
+    sortArray(data);
+}).toCompleteWithin(10, {
+    setup: () => generateRandomArray(1000),
+});
 ```
 
 ### `.toCompleteWithinQuantile(ms, options)`
@@ -159,9 +166,9 @@ expect(() => {
 }).toCompleteWithinQuantile(10, { iterations: 100, quantile: 95, warmup: 5, outliers: 'remove' });
 ```
 
-### `.toResolveWithin(ms)`
+### `.toResolveWithin(ms, options?)`
 
-Assert that asynchronous code resolves within the given duration:
+Assert that asynchronous code resolves within the given duration. Supports optional `setup`/`teardown` callbacks (`setup` return value is passed to the callback and teardown; may return a Promise):
 
 ```ts
 await expect(async () => {
@@ -208,6 +215,47 @@ await expect(async () => {
 | `quantile` | `number` | Yes | Percentile threshold, 1-100 (e.g., `95` means P95) |
 | `warmup` | `number` | No | Warmup iterations to run before measurement (default: `0`) |
 | `outliers` | `'remove' \| 'keep'` | No | Whether to remove IQR-based outliers before computing the quantile (default: `'keep'`) |
+| `setup` | `() => T` | No | Called **once** before all iterations. Its return value is passed to `setupEach`, the callback, `teardownEach`, and `teardown`. Errors are fatal |
+| `teardown` | `(suiteState: T) => void` | No | Called **once** after all iterations. Receives the `setup` return value. Errors are fatal |
+| `setupEach` | `(suiteState: T) => U` | No | Called before **each** iteration (including warmup), not timed. Receives the `setup` return value; its own return value is passed to the callback and `teardownEach`. Errors are fatal |
+| `teardownEach` | `(suiteState: T, iterState: U) => void` | No | Called after **each** iteration (including warmup), not timed. Receives both `setup` and `setupEach` return values. Errors are fatal |
+
+> **Note:** For async matchers (`toResolveWithinQuantile`), `setup` and `setupEach` may return a `Promise` (the resolved value is forwarded), and `teardown`/`teardownEach` may return a `Promise`.
+
+#### Setup/teardown example
+
+```ts
+// setup runs once, setupEach runs per iteration — callback receives both
+expect((conn: DbConnection, data: Row[]) => {
+    processRows(conn, data);
+}).toCompleteWithinQuantile(10, {
+    iterations: 100,
+    quantile: 95,
+    setup: (): DbConnection => createDbConnection(),
+    setupEach: (conn: DbConnection): Row[] => conn.query('SELECT * FROM test_data'),
+    teardownEach: (conn: DbConnection, data: Row[]) => { /* per-iteration cleanup */ },
+    teardown: (conn: DbConnection) => conn.close(),
+});
+```
+
+#### Async setup/teardown example
+
+```ts
+// Async hooks — setup opens a pool once, setupEach fetches fresh data per iteration
+await expect(async (pool: Pool, rows: Row[]) => {
+    await processRows(pool, rows);
+}).toResolveWithinQuantile(50, {
+    iterations: 100,
+    quantile: 95,
+    warmup: 5,
+    setup: async (): Promise<Pool> => await createConnectionPool(),
+    setupEach: async (pool: Pool): Promise<Row[]> => await pool.query('SELECT * FROM test_data'),
+    teardownEach: async (pool: Pool, rows: Row[]) => { await pool.query('DELETE FROM temp'); },
+    teardown: async (pool: Pool) => { await pool.close(); },
+});
+```
+
+Setup, teardown, setupEach, and teardownEach time is excluded from measurements. If any throws, the test fails immediately — these are test infrastructure errors, not tolerated failures.
 
 ## Failure diagnostics
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,22 @@ function validateDuration(expectedDurationInMilliseconds: number): void {
     }
 }
 
-function validateQuantileOptions(options: { iterations: number, quantile: number, warmup?: number, outliers?: 'remove' | 'keep' }): void {
+function validateSetupTeardown(options?: { setup?: unknown, teardown?: unknown, setupEach?: unknown, teardownEach?: unknown }): void {
+    if (options?.setup !== undefined && typeof options.setup !== 'function') {
+        throw new Error(`jest-performance-matchers: setup must be a function if provided, received ${typeof options.setup}`);
+    }
+    if (options?.teardown !== undefined && typeof options.teardown !== 'function') {
+        throw new Error(`jest-performance-matchers: teardown must be a function if provided, received ${typeof options.teardown}`);
+    }
+    if (options?.setupEach !== undefined && typeof options.setupEach !== 'function') {
+        throw new Error(`jest-performance-matchers: setupEach must be a function if provided, received ${typeof options.setupEach}`);
+    }
+    if (options?.teardownEach !== undefined && typeof options.teardownEach !== 'function') {
+        throw new Error(`jest-performance-matchers: teardownEach must be a function if provided, received ${typeof options.teardownEach}`);
+    }
+}
+
+function validateQuantileOptions(options: { iterations: number, quantile: number, warmup?: number, outliers?: 'remove' | 'keep', setup?: unknown, teardown?: unknown, setupEach?: unknown, teardownEach?: unknown }): void {
     if (!options || typeof options !== 'object') {
         throw new Error('jest-performance-matchers: options must be an object with iterations and quantile');
     }
@@ -37,21 +52,34 @@ function validateQuantileOptions(options: { iterations: number, quantile: number
     if (options.outliers !== undefined && options.outliers !== 'remove' && options.outliers !== 'keep') {
         throw new Error(`jest-performance-matchers: outliers must be 'remove' or 'keep', received '${options.outliers}'`);
     }
+    validateSetupTeardown(options);
 }
 
 /**
  * Assert that the synchronous code runs within the given duration.
  * @param callback The callback to execute and measure
  * @param expectedDurationInMilliseconds The expected duration in milliseconds
+ * @param options Optional setup/teardown hooks — setup runs before timing, teardown after
  **/
-function toCompleteWithin(callback: () => unknown, expectedDurationInMilliseconds: number) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+function toCompleteWithin(callback: (state: any) => unknown, expectedDurationInMilliseconds: number, options?: {
+    setup?: () => unknown,
+    teardown?: (state: unknown) => void,
+}) {
     validateCallback(callback);
     validateDuration(expectedDurationInMilliseconds);
+    validateSetupTeardown(options);
 
-    const t0 = nowInMillis();
-    callback();
-    const t1 = nowInMillis();
-    const actualDuration = t1 - t0;
+    const setupResult = options?.setup ? options.setup() : undefined;
+    let actualDuration: number;
+    try {
+        const t0 = nowInMillis();
+        callback(setupResult);
+        const t1 = nowInMillis();
+        actualDuration = t1 - t0;
+    } finally {
+        if (options?.teardown) options.teardown(setupResult);
+    }
 
     return assertDuration(actualDuration, expectedDurationInMilliseconds);
 }
@@ -60,13 +88,18 @@ function toCompleteWithin(callback: () => unknown, expectedDurationInMillisecond
  * Assert that the synchronous code executed for (I) times, runs (Q)% the time within the given duration
  * @param callback The callback to execute and measure
  * @param expectedDurationInMilliseconds The expected duration in milliseconds
- * @param options The numbers of times to execute the callback and the quantile to measure
+ * @param options Iteration count, quantile threshold, and optional setup/teardown hooks
  */
-function toCompleteWithinQuantile(callback: () => unknown, expectedDurationInMilliseconds: number, options: {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+function toCompleteWithinQuantile(callback: (...args: any[]) => unknown, expectedDurationInMilliseconds: number, options: {
     iterations: number,
     quantile: number,
     warmup?: number,
-    outliers?: 'remove' | 'keep'
+    outliers?: 'remove' | 'keep',
+    setup?: () => unknown,
+    teardown?: (suiteState: unknown) => void,
+    setupEach?: (suiteState: unknown) => unknown,
+    teardownEach?: (suiteState: unknown, iterState: unknown) => void,
 }) {
     validateCallback(callback);
     validateDuration(expectedDurationInMilliseconds);
@@ -75,36 +108,67 @@ function toCompleteWithinQuantile(callback: () => unknown, expectedDurationInMil
     const count = options.iterations;
     const quantile = options.quantile;
     const warmup = options.warmup ?? 0;
+    const { setup, teardown, setupEach, teardownEach } = options;
 
-    for (let i = 0; i < warmup; i++) {
-        callback();
-    }
+    const suiteState = setup ? setup() : undefined;
 
-    const durations: number[] = [];
-    for (let i = 0; i < count; i++) {
-        const t0 = nowInMillis();
-        callback();
-        const t1 = nowInMillis();
-        durations.push(t1 - t0);
+    try {
+        for (let i = 0; i < warmup; i++) {
+            const iterState = setupEach ? setupEach(suiteState) : undefined;
+            try {
+                callback(suiteState, iterState);
+            } finally {
+                if (teardownEach) teardownEach(suiteState, iterState);
+            }
+        }
+
+        const durations: number[] = [];
+        for (let i = 0; i < count; i++) {
+            const iterState = setupEach ? setupEach(suiteState) : undefined;
+            try {
+                const t0 = nowInMillis();
+                callback(suiteState, iterState);
+                const t1 = nowInMillis();
+                durations.push(t1 - t0);
+            } finally {
+                if (teardownEach) teardownEach(suiteState, iterState);
+            }
+        }
+
+        const effectiveDurations = options.outliers === 'remove' ? removeOutliers(durations) : durations;
+        const quantileValue = calcQuantile(quantile, effectiveDurations);
+        const setupTeardownActive = !!(setup || teardown || setupEach || teardownEach);
+        return assertDurationQuantile(count, quantile, quantileValue, effectiveDurations, expectedDurationInMilliseconds, setupTeardownActive);
+    } finally {
+        if (teardown) teardown(suiteState);
     }
-    const effectiveDurations = options.outliers === 'remove' ? removeOutliers(durations) : durations;
-    const quantileValue = calcQuantile(quantile, effectiveDurations);
-    return assertDurationQuantile(count, quantile, quantileValue, effectiveDurations, expectedDurationInMilliseconds);
 }
 
 /**
  * Assert that the asynchronous code resolves within the given duration.
  * @param promise The promise to execute and measure
  * @param expectedDurationInMilliseconds The expected duration in milliseconds
+ * @param options Optional setup/teardown hooks — setup runs before timing, teardown after
  */
-async function toResolveWithin(promise: () => Promise<unknown>, expectedDurationInMilliseconds: number) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+async function toResolveWithin(promise: (state: any) => Promise<unknown>, expectedDurationInMilliseconds: number, options?: {
+    setup?: () => unknown | Promise<unknown>,
+    teardown?: (state: unknown) => void | Promise<void>,
+}) {
     validateCallback(promise);
     validateDuration(expectedDurationInMilliseconds);
+    validateSetupTeardown(options);
 
-    const t0 = nowInMillis();
-    await promise();
-    const t1 = nowInMillis();
-    const actualDuration = t1 - t0;
+    const setupResult = options?.setup ? await options.setup() : undefined;
+    let actualDuration: number;
+    try {
+        const t0 = nowInMillis();
+        await promise(setupResult);
+        const t1 = nowInMillis();
+        actualDuration = t1 - t0;
+    } finally {
+        if (options?.teardown) await options.teardown(setupResult);
+    }
     return assertDuration(actualDuration, expectedDurationInMilliseconds);
 }
 
@@ -112,13 +176,18 @@ async function toResolveWithin(promise: () => Promise<unknown>, expectedDuration
  * Assert that the asynchronous code executed for (I) times, resolves (Q)% the time within the given duration
  * @param promise The promise to execute and measure
  * @param expectedDurationInMilliseconds The expected duration in milliseconds
- * @param options The numbers of times to execute the callback and the quantile to measure
+ * @param options Iteration count, quantile threshold, and optional setup/teardown hooks
  */
-async function toResolveWithinQuantile(promise: () => Promise<unknown>, expectedDurationInMilliseconds: number, options: {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+async function toResolveWithinQuantile(promise: (...args: any[]) => Promise<unknown>, expectedDurationInMilliseconds: number, options: {
     iterations: number,
     quantile: number,
     warmup?: number,
-    outliers?: 'remove' | 'keep'
+    outliers?: 'remove' | 'keep',
+    setup?: () => unknown | Promise<unknown>,
+    teardown?: (suiteState: unknown) => void | Promise<void>,
+    setupEach?: (suiteState: unknown) => unknown | Promise<unknown>,
+    teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>,
 }) {
     validateCallback(promise);
     validateDuration(expectedDurationInMilliseconds);
@@ -127,28 +196,47 @@ async function toResolveWithinQuantile(promise: () => Promise<unknown>, expected
     const count = options.iterations;
     const quantile = options.quantile;
     const warmup = options.warmup ?? 0;
+    const { setup, teardown, setupEach, teardownEach } = options;
 
-    for (let i = 0; i < warmup; i++) {
-        await promise();
-    }
+    const suiteState = setup ? await setup() : undefined;
 
-    const durations: number[] = [];
-    for (let i = 0; i < count; i++) {
-        const t0 = nowInMillis();
-        await promise();
-        const t1 = nowInMillis();
-        durations.push(t1 - t0);
+    try {
+        for (let i = 0; i < warmup; i++) {
+            const iterState = setupEach ? await setupEach(suiteState) : undefined;
+            try {
+                await promise(suiteState, iterState);
+            } finally {
+                if (teardownEach) await teardownEach(suiteState, iterState);
+            }
+        }
+
+        const durations: number[] = [];
+        for (let i = 0; i < count; i++) {
+            const iterState = setupEach ? await setupEach(suiteState) : undefined;
+            try {
+                const t0 = nowInMillis();
+                await promise(suiteState, iterState);
+                const t1 = nowInMillis();
+                durations.push(t1 - t0);
+            } finally {
+                if (teardownEach) await teardownEach(suiteState, iterState);
+            }
+        }
+
+        const effectiveDurations = options.outliers === 'remove' ? removeOutliers(durations) : durations;
+        const quantileValue = calcQuantile(quantile, effectiveDurations);
+        const setupTeardownActive = !!(setup || teardown || setupEach || teardownEach);
+        return assertDurationQuantile(count, quantile, quantileValue, effectiveDurations, expectedDurationInMilliseconds, setupTeardownActive);
+    } finally {
+        if (teardown) await teardown(suiteState);
     }
-    const effectiveDurations = options.outliers === 'remove' ? removeOutliers(durations) : durations;
-    const quantileValue = calcQuantile(quantile, effectiveDurations);
-    return assertDurationQuantile(count, quantile, quantileValue, effectiveDurations, expectedDurationInMilliseconds);
 }
 
 function formatStatValue(value: number | null): string {
     return value === null ? 'N/A' : value.toFixed(2);
 }
 
-function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: number): string {
+function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: number, setupTeardownActive?: boolean): string {
     const rmeTag = classifyRME(stats.relativeMarginOfError);
     const cvTag = classifyCV(stats.coefficientOfVariation);
 
@@ -171,7 +259,7 @@ function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: 
     const skewnessText = stats.skewness === null ? 'N/A' : stats.skewness.toFixed(2);
 
     const lines = [
-        `Statistics (n=${stats.n}): mean=${formatStatValue(stats.mean)}ms, median=${formatStatValue(stats.median)}ms, stddev=${formatStatValue(stats.stddev)}ms`,
+        `Statistics (n=${stats.n}${setupTeardownActive ? ', setup/teardown active' : ''}): mean=${formatStatValue(stats.mean)}ms, median=${formatStatValue(stats.median)}ms, stddev=${formatStatValue(stats.stddev)}ms`,
         ciText,
         rmeText,
         cvText,
@@ -191,9 +279,9 @@ function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: 
     return lines.join('\n');
 }
 
-function assertDurationQuantile(iterations: number, quantile: number,  quantileValue: number, durations: number[], expectedDurationInMilliseconds: number) {
+function assertDurationQuantile(iterations: number, quantile: number,  quantileValue: number, durations: number[], expectedDurationInMilliseconds: number, setupTeardownActive?: boolean) {
     const stats = calcStats(durations);
-    const statsBlock = formatStatsBlock(stats, durations, expectedDurationInMilliseconds);
+    const statsBlock = formatStatsBlock(stats, durations, expectedDurationInMilliseconds, setupTeardownActive);
 
     if (quantileValue <= expectedDurationInMilliseconds) {
         return {
@@ -240,22 +328,36 @@ expect.extend({
 declare global {
     namespace jest {
         interface Matchers<R> {
-            toCompleteWithin(expectedDurationInMilliseconds: number): R;
-
-            toCompleteWithinQuantile(expectedDurationInMilliseconds: number, options: {
-                iterations: number,
-                quantile: number,
-                warmup?: number,
-                outliers?: 'remove' | 'keep'
+            toCompleteWithin<T = void>(expectedDurationInMilliseconds: number, options?: {
+                setup?: () => T,
+                teardown?: (state: T) => void,
             }): R;
 
-            toResolveWithin(expectedDurationInMilliseconds: number): Promise<R>;
-
-            toResolveWithinQuantile(expectedDurationInMilliseconds: number, options: {
+            toCompleteWithinQuantile<T = void, U = void>(expectedDurationInMilliseconds: number, options: {
                 iterations: number,
                 quantile: number,
                 warmup?: number,
-                outliers?: 'remove' | 'keep'
+                outliers?: 'remove' | 'keep',
+                setup?: () => T,
+                teardown?: (suiteState: T) => void,
+                setupEach?: (suiteState: T) => U,
+                teardownEach?: (suiteState: T, iterState: U) => void,
+            }): R;
+
+            toResolveWithin<T = void>(expectedDurationInMilliseconds: number, options?: {
+                setup?: () => T | Promise<T>,
+                teardown?: (state: T) => void | Promise<void>,
+            }): Promise<R>;
+
+            toResolveWithinQuantile<T = void, U = void>(expectedDurationInMilliseconds: number, options: {
+                iterations: number,
+                quantile: number,
+                warmup?: number,
+                outliers?: 'remove' | 'keep',
+                setup?: () => T | Promise<T>,
+                teardown?: (suiteState: T) => void | Promise<void>,
+                setupEach?: (suiteState: T) => U | Promise<U>,
+                teardownEach?: (suiteState: T, iterState: U) => void | Promise<void>,
             }): Promise<R>;
         }
     }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -9,7 +9,7 @@ function mockFunctionProcessTime(milliseconds: number) {
     mockFunctionProcessTimes([milliseconds]);
 }
 
-function buildStatsBlock(durations: number[], expectedDuration?: number): string {
+function buildStatsBlock(durations: number[], expectedDuration?: number, setupTeardownActive?: boolean): string {
     const stats = metrics.calcStats(durations);
     const fmt = (v: number | null) => v !== null ? v.toFixed(2) : 'N/A';
 
@@ -35,7 +35,7 @@ function buildStatsBlock(durations: number[], expectedDuration?: number): string
     const skewnessText = stats.skewness === null ? 'N/A' : stats.skewness.toFixed(2);
 
     const lines = [
-        `Statistics (n=${stats.n}): mean=${fmt(stats.mean)}ms, median=${fmt(stats.median)}ms, stddev=${fmt(stats.stddev)}ms`,
+        `Statistics (n=${stats.n}${setupTeardownActive ? ', setup/teardown active' : ''}): mean=${fmt(stats.mean)}ms, median=${fmt(stats.median)}ms, stddev=${fmt(stats.stddev)}ms`,
         ciText,
         rmeText,
         cvText,
@@ -119,6 +119,187 @@ describe("Test jest expect.toCompleteWithin assertion", () => {
     });
 });
 
+describe("Setup/teardown options for toCompleteWithin", () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("should call setup before timing and teardown after when both hooks are provided", () => {
+        // GIVEN a callback with setup and teardown hooks that record their call order
+        const actualCallOrder: string[] = [];
+        jest.spyOn(process, "hrtime").mockImplementation(() => {
+            actualCallOrder.push('hrtime');
+            return [1, 0];
+        });
+
+        // WHEN asserting toCompleteWithin with both hooks
+        expect(() => {
+            actualCallOrder.push('callback');
+        }).toCompleteWithin(1000, {
+            setup: () => { actualCallOrder.push('setup'); },
+            teardown: () => { actualCallOrder.push('teardown'); },
+        });
+
+        // THEN the call order is setup → hrtime(t0) → callback → hrtime(t1) → teardown
+        const expectedCallOrder = ['setup', 'hrtime', 'callback', 'hrtime', 'teardown'];
+        expect(actualCallOrder).toEqual(expectedCallOrder);
+    });
+
+    test("should propagate setup error immediately when setup throws", () => {
+        // GIVEN a function that completes within the budget
+        mockFunctionProcessTime(10);
+        const givenSetupError = "foo-setup-error";
+
+        // WHEN setup throws an error
+        // THEN the error propagates immediately
+        expect(() => {
+            expect(() => undefined).toCompleteWithin(10, {
+                setup: () => { throw new Error(givenSetupError); },
+            });
+        }).toThrowError(givenSetupError);
+    });
+
+    test("should propagate teardown error immediately when teardown throws", () => {
+        // GIVEN a function that completes within the budget
+        mockFunctionProcessTime(10);
+        const givenTeardownError = "foo-teardown-error";
+
+        // WHEN teardown throws an error
+        // THEN the error propagates immediately
+        expect(() => {
+            expect(() => undefined).toCompleteWithin(10, {
+                teardown: () => { throw new Error(givenTeardownError); },
+            });
+        }).toThrowError(givenTeardownError);
+    });
+
+    test("should pass the assertion when no options are provided (backward compatible)", () => {
+        // GIVEN a function that completes within the budget
+        mockFunctionProcessTime(10);
+
+        // WHEN asserting toCompleteWithin without options
+        // THEN expect success (backward compatible)
+        expect(() => undefined).toCompleteWithin(10);
+    });
+
+    test("should throw validation error when setup is not a function", () => {
+        // GIVEN an invalid setup value that is not a function
+        const givenInvalidSetup = 42;
+
+        // WHEN asserting toCompleteWithin with the invalid setup
+        // THEN a validation error is thrown
+        expect(() => {
+            // @ts-expect-error - intentionally passing invalid setup for testing
+            expect(() => undefined).toCompleteWithin(10, { setup: givenInvalidSetup });
+        }).toThrowError("jest-performance-matchers: setup must be a function if provided, received number");
+    });
+
+    test("should throw validation error when teardown is not a function", () => {
+        // GIVEN an invalid teardown value that is not a function
+        const givenInvalidTeardown = "foo-not-a-function";
+
+        // WHEN asserting toCompleteWithin with the invalid teardown
+        // THEN a validation error is thrown
+        expect(() => {
+            // @ts-expect-error - intentionally passing invalid teardown for testing
+            expect(() => undefined).toCompleteWithin(10, { teardown: givenInvalidTeardown });
+        }).toThrowError("jest-performance-matchers: teardown must be a function if provided, received string");
+    });
+
+    test("should pass setup return value to callback and teardown when setup returns a value", () => {
+        // GIVEN a function with setup that returns data
+        mockFunctionProcessTime(10);
+        const givenSetupData = ["foo-item-1", "foo-item-2"];
+        const actualCallbackArgs: unknown[] = [];
+        const actualTeardownArgs: unknown[] = [];
+
+        // WHEN asserting toCompleteWithin with setup that returns a value
+        expect((data: unknown) => {
+            actualCallbackArgs.push(data);
+        }).toCompleteWithin(10, {
+            setup: () => givenSetupData,
+            teardown: (data) => { actualTeardownArgs.push(data); },
+        });
+
+        // THEN the callback receives the setup return value
+        const expectedArgs = [givenSetupData];
+        expect(actualCallbackArgs).toEqual(expectedArgs);
+        // AND the teardown receives the same value
+        expect(actualTeardownArgs).toEqual(expectedArgs);
+    });
+
+    test("should pass undefined to callback when no setup is provided", () => {
+        // GIVEN a function with no setup hook
+        mockFunctionProcessTime(10);
+        const actualCallbackArgs: unknown[] = [];
+
+        // WHEN asserting toCompleteWithin without setup
+        expect((data: unknown) => {
+            actualCallbackArgs.push(data);
+        }).toCompleteWithin(10);
+
+        // THEN the callback receives undefined as the state argument
+        expect(actualCallbackArgs).toEqual([undefined]);
+    });
+
+    test("should call teardown when no setup is provided (teardown-only)", () => {
+        // GIVEN a function with only a teardown hook (no setup)
+        mockFunctionProcessTime(10);
+        const givenTeardownFn = jest.fn();
+
+        // WHEN asserting toCompleteWithin with only teardown
+        expect(() => undefined).toCompleteWithin(10, {
+            teardown: givenTeardownFn,
+        });
+
+        // THEN teardown is called once
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        // AND teardown receives undefined since no setup was provided
+        expect(givenTeardownFn).toHaveBeenCalledWith(undefined);
+    });
+
+    test("should still call teardown when callback throws", () => {
+        // GIVEN a callback that throws and a teardown hook
+        mockFunctionProcessTime(10);
+        const givenSetupState = "foo-state";
+        const givenTeardownFn = jest.fn();
+        const givenCallbackError = "foo-callback-error";
+
+        // WHEN the callback throws an error
+        expect(() => {
+            expect(() => { throw new Error(givenCallbackError); }).toCompleteWithin(10, {
+                setup: () => givenSetupState,
+                teardown: givenTeardownFn,
+            });
+        }).toThrowError(givenCallbackError);
+
+        // THEN teardown is still called via try/finally with the setup state
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        // AND teardown receives the setup return value
+        expect(givenTeardownFn).toHaveBeenCalledWith(givenSetupState);
+    });
+
+    test("should call teardown and throw negation error when .not is used with setup/teardown hooks", () => {
+        // GIVEN a function that completes within the budget and has setup/teardown hooks
+        mockFunctionProcessTime(10);
+        const givenSetupState = "foo-state";
+        const givenTeardownFn = jest.fn();
+
+        // WHEN using .not negation (expecting the assertion to fail)
+        expect(() => {
+            expect(() => undefined).not.toCompleteWithin(10, {
+                setup: () => givenSetupState,
+                teardown: givenTeardownFn,
+            });
+        }).toThrowError(/to be greater than/);
+
+        // THEN teardown is still called despite the negation error
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        // AND teardown receives the setup return value
+        expect(givenTeardownFn).toHaveBeenCalledWith(givenSetupState);
+    });
+});
+
 describe("Test jest expect.toResolveWithin assertion", () => {
     beforeEach(() => {
         jest.restoreAllMocks();
@@ -191,6 +372,227 @@ describe("Test jest expect.toResolveWithin assertion", () => {
         await expect(mockFn).toResolveWithin(T);
         // THEN expect the promise to have been called once
         expect(mockFn).toBeCalledTimes(1);
+    });
+});
+
+describe("Setup/teardown options for toResolveWithin", () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("should call setup before timing and teardown after when both hooks are provided", async () => {
+        // GIVEN a promise with setup and teardown hooks that record their call order
+        const actualCallOrder: string[] = [];
+        jest.spyOn(process, "hrtime").mockImplementation(() => {
+            actualCallOrder.push('hrtime');
+            return [1, 0];
+        });
+
+        // WHEN asserting toResolveWithin with both hooks
+        await expect(async () => {
+            actualCallOrder.push('callback');
+        }).toResolveWithin(1000, {
+            setup: () => { actualCallOrder.push('setup'); },
+            teardown: () => { actualCallOrder.push('teardown'); },
+        });
+
+        // THEN the call order is setup → hrtime(t0) → callback → hrtime(t1) → teardown
+        const expectedCallOrder = ['setup', 'hrtime', 'callback', 'hrtime', 'teardown'];
+        expect(actualCallOrder).toEqual(expectedCallOrder);
+    });
+
+    test("should await async setup and teardown when both return Promises", async () => {
+        // GIVEN a promise with async setup and teardown hooks
+        mockFunctionProcessTime(10);
+        const actualOrder: string[] = [];
+
+        // WHEN asserting toResolveWithin with async hooks
+        await expect(async () => {
+            actualOrder.push('callback');
+        }).toResolveWithin(10, {
+            setup: async () => { actualOrder.push('setup'); },
+            teardown: async () => { actualOrder.push('teardown'); },
+        });
+
+        // THEN setup and teardown are awaited in order
+        const expectedOrder = ['setup', 'callback', 'teardown'];
+        expect(actualOrder).toEqual(expectedOrder);
+    });
+
+    test("should propagate async setup rejection immediately when setup rejects", async () => {
+        // GIVEN a promise that resolves within the budget
+        mockFunctionProcessTime(10);
+        const givenSetupError = "foo-async-setup-error";
+
+        // WHEN async setup rejects
+        // THEN the rejection propagates immediately
+        await expect(
+            expect(async () => await Promise.resolve()).toResolveWithin(10, {
+                setup: async () => { throw new Error(givenSetupError); },
+            })
+        ).rejects.toThrowError(givenSetupError);
+    });
+
+    test("should propagate async teardown rejection immediately when teardown rejects", async () => {
+        // GIVEN a promise that resolves within the budget
+        mockFunctionProcessTime(10);
+        const givenTeardownError = "foo-async-teardown-error";
+
+        // WHEN async teardown rejects
+        // THEN the rejection propagates immediately
+        await expect(
+            expect(async () => await Promise.resolve()).toResolveWithin(10, {
+                teardown: async () => { throw new Error(givenTeardownError); },
+            })
+        ).rejects.toThrowError(givenTeardownError);
+    });
+
+    test("should pass the assertion when no options are provided (backward compatible)", async () => {
+        // GIVEN a promise that resolves within the budget
+        mockFunctionProcessTime(10);
+
+        // WHEN asserting toResolveWithin without options
+        // THEN expect success (backward compatible)
+        await expect(async () => await Promise.resolve()).toResolveWithin(10);
+    });
+
+    test("should throw validation error when setup is not a function", async () => {
+        // GIVEN an invalid setup value that is not a function
+        const givenInvalidSetup = 42;
+
+        // WHEN asserting toResolveWithin with the invalid setup
+        // THEN a validation error is thrown
+        await expect(async () => {
+            // @ts-expect-error - intentionally passing invalid setup for testing
+            await expect(async () => Promise.resolve()).toResolveWithin(10, { setup: givenInvalidSetup });
+        }).rejects.toThrowError("jest-performance-matchers: setup must be a function if provided, received number");
+    });
+
+    test("should throw validation error when teardown is not a function", async () => {
+        // GIVEN an invalid teardown value that is not a function
+        const givenInvalidTeardown = "foo-not-a-function";
+
+        // WHEN asserting toResolveWithin with the invalid teardown
+        // THEN a validation error is thrown
+        await expect(async () => {
+            // @ts-expect-error - intentionally passing invalid teardown for testing
+            await expect(async () => Promise.resolve()).toResolveWithin(10, { teardown: givenInvalidTeardown });
+        }).rejects.toThrowError("jest-performance-matchers: teardown must be a function if provided, received string");
+    });
+
+    test("should pass setup return value to callback and teardown when setup returns a value", async () => {
+        // GIVEN a promise with setup that returns data
+        mockFunctionProcessTime(10);
+        const givenSetupData = { key: "foo-value" };
+        const actualCallbackArgs: unknown[] = [];
+        const actualTeardownArgs: unknown[] = [];
+
+        // WHEN asserting toResolveWithin with setup that returns a value
+        await expect(async (data: unknown) => {
+            actualCallbackArgs.push(data);
+        }).toResolveWithin(10, {
+            setup: () => givenSetupData,
+            teardown: (data) => { actualTeardownArgs.push(data); },
+        });
+
+        // THEN the callback receives the setup return value
+        const expectedArgs = [givenSetupData];
+        expect(actualCallbackArgs).toEqual(expectedArgs);
+        // AND the teardown receives the same value
+        expect(actualTeardownArgs).toEqual(expectedArgs);
+    });
+
+    test("should pass resolved value to callback and teardown when async setup returns a Promise", async () => {
+        // GIVEN a promise with async setup that resolves to a value
+        mockFunctionProcessTime(10);
+        const givenResolvedValue = "foo-async-result";
+        const actualCallbackArgs: unknown[] = [];
+        const actualTeardownArgs: unknown[] = [];
+
+        // WHEN asserting toResolveWithin with async setup
+        await expect(async (data: unknown) => {
+            actualCallbackArgs.push(data);
+        }).toResolveWithin(10, {
+            setup: async () => givenResolvedValue,
+            teardown: (data) => { actualTeardownArgs.push(data); },
+        });
+
+        // THEN the callback receives the resolved value
+        const expectedArgs = [givenResolvedValue];
+        expect(actualCallbackArgs).toEqual(expectedArgs);
+        // AND the teardown receives the same resolved value
+        expect(actualTeardownArgs).toEqual(expectedArgs);
+    });
+
+    test("should pass undefined to callback when no setup is provided", async () => {
+        // GIVEN a promise with no setup hook
+        mockFunctionProcessTime(10);
+        const actualCallbackArgs: unknown[] = [];
+
+        // WHEN asserting toResolveWithin without setup
+        await expect(async (data: unknown) => {
+            actualCallbackArgs.push(data);
+        }).toResolveWithin(10);
+
+        // THEN the callback receives undefined as the state argument
+        expect(actualCallbackArgs).toEqual([undefined]);
+    });
+
+    test("should call teardown when no setup is provided (teardown-only)", async () => {
+        // GIVEN a promise with only a teardown hook (no setup)
+        mockFunctionProcessTime(10);
+        const givenTeardownFn = jest.fn();
+
+        // WHEN asserting toResolveWithin with only teardown
+        await expect(async () => await Promise.resolve()).toResolveWithin(10, {
+            teardown: givenTeardownFn,
+        });
+
+        // THEN teardown is called once
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        // AND teardown receives undefined since no setup was provided
+        expect(givenTeardownFn).toHaveBeenCalledWith(undefined);
+    });
+
+    test("should still call teardown when promise rejects", async () => {
+        // GIVEN a promise that rejects and a teardown hook
+        mockFunctionProcessTime(10);
+        const givenSetupState = "foo-state";
+        const givenTeardownFn = jest.fn();
+        const givenPromiseError = "foo-promise-error";
+
+        // WHEN the promise rejects
+        await expect(
+            expect(async () => { throw new Error(givenPromiseError); }).toResolveWithin(10, {
+                setup: () => givenSetupState,
+                teardown: givenTeardownFn,
+            })
+        ).rejects.toThrowError(givenPromiseError);
+
+        // THEN teardown is still called via try/finally with the setup state
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        // AND teardown receives the setup return value
+        expect(givenTeardownFn).toHaveBeenCalledWith(givenSetupState);
+    });
+
+    test("should call teardown and reject with negation error when .not is used with setup/teardown hooks", async () => {
+        // GIVEN a promise that resolves within the budget and has setup/teardown hooks
+        mockFunctionProcessTime(10);
+        const givenSetupState = "foo-state";
+        const givenTeardownFn = jest.fn();
+
+        // WHEN using .not negation (expecting the assertion to fail)
+        await expect(async () => {
+            await expect(async () => await Promise.resolve()).not.toResolveWithin(10, {
+                setup: () => givenSetupState,
+                teardown: givenTeardownFn,
+            });
+        }).rejects.toThrowError(/to be greater than/);
+
+        // THEN teardown is still called despite the negation error
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        // AND teardown receives the setup return value
+        expect(givenTeardownFn).toHaveBeenCalledWith(givenSetupState);
     });
 });
 
@@ -551,6 +953,783 @@ describe("Test jest expect.toCompleteWithinQuantile assertion", () => {
         expect(actualMessage).toContain('Sample adequacy:');
         expect(actualMessage).toContain('Interpretation:');
     });
+});
+
+describe("Setup/teardown options (sync)", () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("should call setup once and teardown once when both are provided", () => {
+        // GIVEN a function with suite-level setup and teardown hooks
+        const givenDuration = 10;
+        const givenIterations = 5;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSetupFn = jest.fn();
+        const givenTeardownFn = jest.fn();
+
+        // WHEN asserting toCompleteWithinQuantile with setup and teardown
+        expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: givenQuantile, setup: givenSetupFn, teardown: givenTeardownFn,
+        });
+
+        // THEN setup is called exactly once (suite-level)
+        expect(givenSetupFn).toHaveBeenCalledTimes(1);
+        // AND teardown is called exactly once (suite-level)
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+    });
+
+    test("should call setupEach before each measured iteration when setupEach is provided", () => {
+        // GIVEN a function with a per-iteration setupEach hook and 5 iterations
+        const givenDuration = 10;
+        const givenIterations = 5;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSetupEachFn = jest.fn();
+
+        // WHEN asserting toCompleteWithinQuantile with setupEach
+        expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: givenQuantile, setupEach: givenSetupEachFn,
+        });
+
+        // THEN setupEach is called once per iteration
+        expect(givenSetupEachFn).toHaveBeenCalledTimes(givenIterations);
+    });
+
+    test("should call teardownEach after each measured iteration when teardownEach is provided", () => {
+        // GIVEN a function with a per-iteration teardownEach hook and 5 iterations
+        const givenDuration = 10;
+        const givenIterations = 5;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenTeardownEachFn = jest.fn();
+
+        // WHEN asserting toCompleteWithinQuantile with teardownEach
+        expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: givenQuantile, teardownEach: givenTeardownEachFn,
+        });
+
+        // THEN teardownEach is called once per iteration
+        expect(givenTeardownEachFn).toHaveBeenCalledTimes(givenIterations);
+    });
+
+    test("should call setupEach and teardownEach during warmup iterations when warmup is configured", () => {
+        // GIVEN a function with per-iteration hooks, 3 measured iterations and 2 warmup iterations
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        const givenWarmup = 2;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSetupEachFn = jest.fn();
+        const givenTeardownEachFn = jest.fn();
+
+        // WHEN asserting toCompleteWithinQuantile with warmup
+        expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: givenQuantile, warmup: givenWarmup,
+            setupEach: givenSetupEachFn, teardownEach: givenTeardownEachFn,
+        });
+
+        // THEN setupEach is called for warmup + measured = total times
+        const expectedTotalCalls = givenWarmup + givenIterations;
+        expect(givenSetupEachFn).toHaveBeenCalledTimes(expectedTotalCalls);
+        // AND teardownEach is called the same number of times
+        expect(givenTeardownEachFn).toHaveBeenCalledTimes(expectedTotalCalls);
+    });
+
+    test("should work with only setupEach (no teardownEach) when only setupEach is provided", () => {
+        // GIVEN a function with only setupEach (no teardownEach)
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSetupEachFn = jest.fn();
+
+        // WHEN asserting toCompleteWithinQuantile with only setupEach
+        expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: givenQuantile, setupEach: givenSetupEachFn,
+        });
+
+        // THEN setupEach is called once per iteration
+        expect(givenSetupEachFn).toHaveBeenCalledTimes(givenIterations);
+    });
+
+    test("should work with only teardownEach (no setupEach) when only teardownEach is provided", () => {
+        // GIVEN a function with only teardownEach (no setupEach)
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenTeardownEachFn = jest.fn();
+
+        // WHEN asserting toCompleteWithinQuantile with only teardownEach
+        expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: givenQuantile, teardownEach: givenTeardownEachFn,
+        });
+
+        // THEN teardownEach is called once per iteration
+        expect(givenTeardownEachFn).toHaveBeenCalledTimes(givenIterations);
+    });
+
+    test("should propagate setup error immediately when setup throws", () => {
+        // GIVEN a function with a setup hook that throws
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        const givenSetupError = "foo-setup-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN setup throws an error
+        // THEN the error propagates immediately
+        expect(() => {
+            expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: givenQuantile,
+                setup: () => { throw new Error(givenSetupError); },
+            });
+        }).toThrowError(givenSetupError);
+    });
+
+    test("should propagate teardown error immediately when teardown throws", () => {
+        // GIVEN a function with a teardown hook that throws
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        const givenTeardownError = "foo-teardown-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN teardown throws an error
+        // THEN the error propagates immediately
+        expect(() => {
+            expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: givenQuantile,
+                teardown: () => { throw new Error(givenTeardownError); },
+            });
+        }).toThrowError(givenTeardownError);
+    });
+
+    test("should propagate setupEach error immediately when setupEach throws", () => {
+        // GIVEN a function with a setupEach hook that throws
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        const givenSetupEachError = "foo-setupEach-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN setupEach throws an error
+        // THEN the error propagates immediately
+        expect(() => {
+            expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: givenQuantile,
+                setupEach: () => { throw new Error(givenSetupEachError); },
+            });
+        }).toThrowError(givenSetupEachError);
+    });
+
+    test("should still call teardown when setupEach throws", () => {
+        // GIVEN a function with setupEach that throws and a suite-level teardown
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        const givenSetupEachError = "foo-setupEach-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSuiteState = "foo-suite";
+        const givenTeardownFn = jest.fn();
+
+        // WHEN setupEach throws on the first iteration
+        expect(() => {
+            expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: givenQuantile,
+                setup: () => givenSuiteState,
+                setupEach: () => { throw new Error(givenSetupEachError); },
+                teardown: givenTeardownFn,
+            });
+        }).toThrowError(givenSetupEachError);
+
+        // THEN teardown is still called via outer try/finally
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        // AND teardown receives the suite state
+        expect(givenTeardownFn).toHaveBeenCalledWith(givenSuiteState);
+    });
+
+    test("should propagate teardownEach error immediately when teardownEach throws", () => {
+        // GIVEN a function with a teardownEach hook that throws
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        const givenTeardownEachError = "foo-teardownEach-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN teardownEach throws an error
+        // THEN the error propagates immediately
+        expect(() => {
+            expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: givenQuantile,
+                teardownEach: () => { throw new Error(givenTeardownEachError); },
+            });
+        }).toThrowError(givenTeardownEachError);
+    });
+
+    test("should show 'setup/teardown active' hint in stats block when setup is provided", () => {
+        // GIVEN a function that exceeds the budget with a setup hook
+        const givenDuration = 10;
+        const givenIterations = 5;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN the assertion fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(givenDuration - 1, {
+                iterations: givenIterations, quantile: givenQuantile,
+                setup: () => { /* noop */ },
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the stats block includes the 'setup/teardown active' hint
+        expect(actualMessage).toContain('setup/teardown active');
+    });
+
+    test("should show 'setup/teardown active' hint in stats block when setupEach is provided", () => {
+        // GIVEN a function that exceeds the budget with a setupEach hook
+        const givenDuration = 10;
+        const givenIterations = 5;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN the assertion fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(givenDuration - 1, {
+                iterations: givenIterations, quantile: givenQuantile,
+                setupEach: () => { /* noop */ },
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the stats block includes the 'setup/teardown active' hint
+        expect(actualMessage).toContain('setup/teardown active');
+    });
+
+    test("should NOT show 'setup/teardown active' hint when no hooks are provided", () => {
+        // GIVEN a function that exceeds the budget without any hooks
+        const givenDuration = 10;
+        const givenIterations = 5;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN the assertion fails
+        let actualMessage = '';
+        try {
+            expect(() => undefined).toCompleteWithinQuantile(givenDuration - 1, {
+                iterations: givenIterations, quantile: givenQuantile,
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the stats block does NOT include the 'setup/teardown active' hint
+        expect(actualMessage).not.toContain('setup/teardown active');
+    });
+
+    test("should show 'setup/teardown active' hint in .not negation message when setup is provided", () => {
+        // GIVEN a function that completes within the budget with a setup hook
+        const givenDuration = 10;
+        const givenIterations = 5;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN using .not negation (expecting the assertion to fail)
+        // THEN the error message includes the 'setup/teardown active' hint
+        expect(() => {
+            expect(() => undefined).not.toCompleteWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: givenQuantile,
+                setup: () => { /* noop */ },
+            });
+        }).toThrowError(/setup\/teardown active/);
+    });
+
+    test("should call setup once, then setupEach before hrtime, then teardownEach after hrtime, then teardown once when all hooks are provided", () => {
+        // GIVEN a callback with all four hooks that record their call order
+        const givenIterations = 1;
+        const givenQuantile = 50;
+        const actualCallOrder: string[] = [];
+        jest.spyOn(process, "hrtime").mockImplementation(() => {
+            actualCallOrder.push('hrtime');
+            return [1, 0];
+        });
+
+        // WHEN asserting toCompleteWithinQuantile with all hooks for 1 iteration
+        expect(() => {
+            actualCallOrder.push('callback');
+        }).toCompleteWithinQuantile(1000, {
+            iterations: givenIterations, quantile: givenQuantile,
+            setup: () => { actualCallOrder.push('setup'); },
+            teardown: () => { actualCallOrder.push('teardown'); },
+            setupEach: () => { actualCallOrder.push('setupEach'); },
+            teardownEach: () => { actualCallOrder.push('teardownEach'); },
+        });
+
+        // THEN the call order is setup(once) → setupEach → hrtime(t0) → callback → hrtime(t1) → teardownEach → teardown(once)
+        const expectedCallOrder = ['setup', 'setupEach', 'hrtime', 'callback', 'hrtime', 'teardownEach', 'teardown'];
+        expect(actualCallOrder).toEqual(expectedCallOrder);
+    });
+
+    test("should pass setup return value to setupEach, callback, teardownEach, and teardown when all hooks return values", () => {
+        // GIVEN a function with all four hooks that return and receive values
+        const givenDuration = 10;
+        const givenIterations = 2;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSuiteData = "foo-suite-state";
+        let givenIterCounter = 0;
+        const actualCallbackArgs: unknown[][] = [];
+        const actualTeardownEachArgs: unknown[][] = [];
+        const actualSetupEachArgs: unknown[] = [];
+        let actualTeardownArg: unknown;
+
+        // WHEN asserting toCompleteWithinQuantile with all four hooks
+        expect((suiteState: unknown, iterState: unknown) => {
+            actualCallbackArgs.push([suiteState, iterState]);
+        }).toCompleteWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: givenQuantile,
+            setup: () => givenSuiteData,
+            setupEach: (suiteState) => { actualSetupEachArgs.push(suiteState); return ++givenIterCounter; },
+            teardownEach: (suiteState, iterState) => { actualTeardownEachArgs.push([suiteState, iterState]); },
+            teardown: (suiteState) => { actualTeardownArg = suiteState; },
+        });
+
+        // THEN setupEach receives suite state
+        expect(actualSetupEachArgs).toEqual([givenSuiteData, givenSuiteData]);
+        // AND callback receives both suite state and iter state
+        expect(actualCallbackArgs).toEqual([[givenSuiteData, 1], [givenSuiteData, 2]]);
+        // AND teardownEach receives both suite state and iter state
+        expect(actualTeardownEachArgs).toEqual([[givenSuiteData, 1], [givenSuiteData, 2]]);
+        // AND teardown receives suite state only
+        expect(actualTeardownArg).toBe(givenSuiteData);
+    });
+
+    test("should pass setup return value during warmup iterations when warmup is configured", () => {
+        // GIVEN a function with suite-level setup and per-iteration setupEach, with warmup
+        const givenDuration = 10;
+        const givenIterations = 2;
+        const givenQuantile = 50;
+        const givenWarmup = 2;
+        const givenSuiteState = "foo-suite";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        let givenIterCounter = 0;
+        const actualCallbackArgs: unknown[][] = [];
+
+        // WHEN asserting toCompleteWithinQuantile with warmup
+        expect((suiteState: unknown, iterState: unknown) => {
+            actualCallbackArgs.push([suiteState, iterState]);
+        }).toCompleteWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: givenQuantile, warmup: givenWarmup,
+            setup: () => givenSuiteState,
+            setupEach: () => ++givenIterCounter,
+        });
+
+        // THEN warmup (2) + measured (2) = 4 calls, all receive suite state and fresh iter state
+        expect(actualCallbackArgs).toEqual([
+            [givenSuiteState, 1], [givenSuiteState, 2], [givenSuiteState, 3], [givenSuiteState, 4],
+        ]);
+    });
+
+    test("should pass undefined for both states when no hooks are provided", () => {
+        // GIVEN a function with no hooks
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const actualCallbackArgs: unknown[][] = [];
+
+        // WHEN asserting toCompleteWithinQuantile without any hooks
+        expect((suiteState: unknown, iterState: unknown) => {
+            actualCallbackArgs.push([suiteState, iterState]);
+        }).toCompleteWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: givenQuantile,
+        });
+
+        // THEN callback receives undefined for both suite and iteration state
+        expect(actualCallbackArgs).toEqual([
+            [undefined, undefined], [undefined, undefined], [undefined, undefined],
+        ]);
+    });
+
+    test("should throw validation error when setupEach is not a function", () => {
+        // GIVEN an invalid setupEach value that is not a function
+        const givenInvalidSetupEach = 42;
+
+        // WHEN asserting toCompleteWithinQuantile with the invalid setupEach
+        // THEN a validation error is thrown
+        expect(() => {
+            // @ts-expect-error - intentionally passing invalid setupEach for testing
+            expect(() => undefined).toCompleteWithinQuantile(10, { iterations: 3, quantile: 50, setupEach: givenInvalidSetupEach });
+        }).toThrowError("jest-performance-matchers: setupEach must be a function if provided, received number");
+    });
+
+    test("should throw validation error when teardownEach is not a function", () => {
+        // GIVEN an invalid teardownEach value that is not a function
+        const givenInvalidTeardownEach = "foo-not-a-function";
+
+        // WHEN asserting toCompleteWithinQuantile with the invalid teardownEach
+        // THEN a validation error is thrown
+        expect(() => {
+            // @ts-expect-error - intentionally passing invalid teardownEach for testing
+            expect(() => undefined).toCompleteWithinQuantile(10, { iterations: 3, quantile: 50, teardownEach: givenInvalidTeardownEach });
+        }).toThrowError("jest-performance-matchers: teardownEach must be a function if provided, received string");
+    });
+
+    test("should still call teardown and teardownEach when callback throws", () => {
+        // GIVEN a callback that throws on first iteration, with suite-level teardown and per-iteration teardownEach
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenQuantile = 50;
+        const givenSuiteState = "foo-suite";
+        const givenCallbackError = "foo-callback-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenTeardownFn = jest.fn();
+        const givenTeardownEachFn = jest.fn();
+
+        // WHEN the callback throws an error on the first iteration
+        expect(() => {
+            expect(() => { throw new Error(givenCallbackError); }).toCompleteWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: givenQuantile,
+                setup: () => givenSuiteState,
+                teardown: givenTeardownFn,
+                teardownEach: givenTeardownEachFn,
+            });
+        }).toThrowError(givenCallbackError);
+
+        // THEN teardownEach is called once (for the failing iteration)
+        expect(givenTeardownEachFn).toHaveBeenCalledTimes(1);
+        // AND teardown is still called once with the suite state
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        expect(givenTeardownFn).toHaveBeenCalledWith(givenSuiteState);
+    });
+});
+
+describe("Setup/teardown options (async)", () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("should call async setup once and teardown once when both are provided", async () => {
+        // GIVEN a promise with suite-level async setup and teardown hooks
+        const givenDuration = 10;
+        const givenIterations = 3;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSetupFn = jest.fn();
+        const givenTeardownFn = jest.fn();
+
+        // WHEN asserting toResolveWithinQuantile with setup and teardown
+        await expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: 50,
+            setup: givenSetupFn, teardown: givenTeardownFn,
+        });
+
+        // THEN setup is called exactly once (suite-level)
+        expect(givenSetupFn).toHaveBeenCalledTimes(1);
+        // AND teardown is called exactly once (suite-level)
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+    });
+
+    test("should call async setupEach and teardownEach for each iteration when both are provided", async () => {
+        // GIVEN a promise with per-iteration async hooks and 3 iterations
+        const givenDuration = 10;
+        const givenIterations = 3;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSetupEachFn = jest.fn();
+        const givenTeardownEachFn = jest.fn();
+
+        // WHEN asserting toResolveWithinQuantile with setupEach and teardownEach
+        await expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: 50,
+            setupEach: givenSetupEachFn, teardownEach: givenTeardownEachFn,
+        });
+
+        // THEN setupEach is called once per iteration
+        expect(givenSetupEachFn).toHaveBeenCalledTimes(givenIterations);
+        // AND teardownEach is called once per iteration
+        expect(givenTeardownEachFn).toHaveBeenCalledTimes(givenIterations);
+    });
+
+    test("should call async setupEach and teardownEach during warmup when warmup is configured", async () => {
+        // GIVEN a promise with per-iteration hooks, 3 measured iterations and 2 warmup iterations
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenWarmup = 2;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSetupEachFn = jest.fn();
+        const givenTeardownEachFn = jest.fn();
+
+        // WHEN asserting toResolveWithinQuantile with warmup
+        await expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: 50, warmup: givenWarmup,
+            setupEach: givenSetupEachFn, teardownEach: givenTeardownEachFn,
+        });
+
+        // THEN setupEach is called for warmup + measured = total times
+        expect(givenSetupEachFn).toHaveBeenCalledTimes(givenWarmup + givenIterations);
+        // AND teardownEach is called the same number of times
+        expect(givenTeardownEachFn).toHaveBeenCalledTimes(givenWarmup + givenIterations);
+    });
+
+    test("should await async setup that returns a Promise when setup is async", async () => {
+        // GIVEN a promise with an async setup hook
+        const givenDuration = 10;
+        const givenIterations = 3;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const actualOrder: string[] = [];
+
+        // WHEN asserting toResolveWithinQuantile with async setup
+        await expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: 50,
+            setup: async () => { actualOrder.push('setup-done'); },
+        });
+
+        // THEN setup is awaited and called once
+        expect(actualOrder).toEqual(['setup-done']);
+    });
+
+    test("should propagate async setup rejection immediately when setup rejects", async () => {
+        // GIVEN a promise with an async setup hook that rejects
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenSetupError = "foo-async-setup-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN async setup rejects
+        // THEN the rejection propagates immediately
+        await expect(
+            expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: 50,
+                setup: async () => { throw new Error(givenSetupError); },
+            })
+        ).rejects.toThrowError(givenSetupError);
+    });
+
+    test("should propagate async teardown rejection immediately when teardown rejects", async () => {
+        // GIVEN a promise with an async teardown hook that rejects
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenTeardownError = "foo-async-teardown-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN async teardown rejects
+        // THEN the rejection propagates immediately
+        await expect(
+            expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: 50,
+                teardown: async () => { throw new Error(givenTeardownError); },
+            })
+        ).rejects.toThrowError(givenTeardownError);
+    });
+
+    test("should propagate async setupEach rejection immediately when setupEach rejects", async () => {
+        // GIVEN a promise with an async setupEach hook that rejects
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenSetupEachError = "foo-async-setupEach-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN async setupEach rejects
+        // THEN the rejection propagates immediately
+        await expect(
+            expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: 50,
+                setupEach: async () => { throw new Error(givenSetupEachError); },
+            })
+        ).rejects.toThrowError(givenSetupEachError);
+    });
+
+    test("should still call teardown when async setupEach rejects", async () => {
+        // GIVEN a promise with async setupEach that rejects and a suite-level teardown
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenSuiteState = "foo-async-suite";
+        const givenSetupEachError = "foo-async-setupEach-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenTeardownFn = jest.fn();
+
+        // WHEN async setupEach rejects on the first iteration
+        await expect(
+            expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: 50,
+                setup: async () => givenSuiteState,
+                setupEach: async () => { throw new Error(givenSetupEachError); },
+                teardown: givenTeardownFn,
+            })
+        ).rejects.toThrowError(givenSetupEachError);
+
+        // THEN teardown is still called via outer try/finally
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        // AND teardown receives the suite state
+        expect(givenTeardownFn).toHaveBeenCalledWith(givenSuiteState);
+    });
+
+    test("should propagate async teardownEach rejection immediately when teardownEach rejects", async () => {
+        // GIVEN a promise with an async teardownEach hook that rejects
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenTeardownEachError = "foo-async-teardownEach-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN async teardownEach rejects
+        // THEN the rejection propagates immediately
+        await expect(
+            expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: 50,
+                teardownEach: async () => { throw new Error(givenTeardownEachError); },
+            })
+        ).rejects.toThrowError(givenTeardownEachError);
+    });
+
+    test("should still call teardown and teardownEach when promise rejects", async () => {
+        // GIVEN a promise that rejects on the first iteration, with suite teardown and per-iteration teardownEach
+        const givenDuration = 10;
+        const givenIterations = 3;
+        const givenSuiteState = "foo-async-suite";
+        const givenPromiseError = "foo-promise-error";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenTeardownFn = jest.fn();
+        const givenTeardownEachFn = jest.fn();
+
+        // WHEN the promise rejects on the first iteration
+        await expect(
+            expect(async () => { throw new Error(givenPromiseError); }).toResolveWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: 50,
+                setup: async () => givenSuiteState,
+                teardown: givenTeardownFn,
+                teardownEach: givenTeardownEachFn,
+            })
+        ).rejects.toThrowError(givenPromiseError);
+
+        // THEN teardownEach is called once (for the failing iteration)
+        expect(givenTeardownEachFn).toHaveBeenCalledTimes(1);
+        // AND teardown is still called once with the suite state
+        expect(givenTeardownFn).toHaveBeenCalledTimes(1);
+        expect(givenTeardownFn).toHaveBeenCalledWith(givenSuiteState);
+    });
+
+    test("should throw validation error when setupEach is not a function", async () => {
+        // GIVEN an invalid setupEach value that is not a function
+        const givenInvalidSetupEach = 42;
+
+        // WHEN asserting toResolveWithinQuantile with the invalid setupEach
+        // THEN a validation error is thrown
+        await expect(async () => {
+            // @ts-expect-error - intentionally passing invalid setupEach for testing
+            await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, { iterations: 3, quantile: 50, setupEach: givenInvalidSetupEach });
+        }).rejects.toThrowError("jest-performance-matchers: setupEach must be a function if provided, received number");
+    });
+
+    test("should throw validation error when teardownEach is not a function", async () => {
+        // GIVEN an invalid teardownEach value that is not a function
+        const givenInvalidTeardownEach = "foo-not-a-function";
+
+        // WHEN asserting toResolveWithinQuantile with the invalid teardownEach
+        // THEN a validation error is thrown
+        await expect(async () => {
+            // @ts-expect-error - intentionally passing invalid teardownEach for testing
+            await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, { iterations: 3, quantile: 50, teardownEach: givenInvalidTeardownEach });
+        }).rejects.toThrowError("jest-performance-matchers: teardownEach must be a function if provided, received string");
+    });
+
+    test("should show 'setup/teardown active' hint in async .not negation message when setup is provided", async () => {
+        // GIVEN a promise that completes within the budget with a setup hook
+        const givenDuration = 10;
+        const givenIterations = 5;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN using .not negation (expecting the assertion to fail)
+        // THEN the error message includes the 'setup/teardown active' hint
+        await expect(async () => {
+            await expect(async () => await Promise.resolve()).not.toResolveWithinQuantile(givenDuration, {
+                iterations: givenIterations, quantile: 50,
+                setup: () => { /* noop */ },
+            });
+        }).rejects.toThrowError(/setup\/teardown active/);
+    });
+
+    test("should show 'setup/teardown active' hint in async failure message when setup is provided", async () => {
+        // GIVEN a promise that exceeds the budget with a setup hook
+        const givenDuration = 10;
+        const givenIterations = 5;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+
+        // WHEN the assertion fails
+        let actualMessage = '';
+        try {
+            await expect(async () => await Promise.resolve()).toResolveWithinQuantile(givenDuration - 1, {
+                iterations: givenIterations, quantile: 50,
+                setup: () => { /* noop */ },
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the stats block includes the 'setup/teardown active' hint
+        expect(actualMessage).toContain('setup/teardown active');
+    });
+
+    test("should pass async setup and setupEach return values to callback and teardownEach when all hooks are provided", async () => {
+        // GIVEN a promise with all four async hooks that return and receive values
+        const givenDuration = 10;
+        const givenIterations = 2;
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        const givenSuiteData = "foo-async-suite";
+        let givenIterCounter = 0;
+        const actualCallbackArgs: unknown[][] = [];
+        const actualTeardownEachArgs: unknown[][] = [];
+        let actualTeardownArg: unknown;
+
+        // WHEN asserting toResolveWithinQuantile with all four hooks
+        await expect(async (suiteState: unknown, iterState: unknown) => {
+            actualCallbackArgs.push([suiteState, iterState]);
+        }).toResolveWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: 50,
+            setup: async () => givenSuiteData,
+            setupEach: async (suiteState) => { return ++givenIterCounter; },
+            teardownEach: (suiteState, iterState) => { actualTeardownEachArgs.push([suiteState, iterState]); },
+            teardown: (suiteState) => { actualTeardownArg = suiteState; },
+        });
+
+        // THEN callback receives both suite state and iter state
+        expect(actualCallbackArgs).toEqual([[givenSuiteData, 1], [givenSuiteData, 2]]);
+        // AND teardownEach receives both
+        expect(actualTeardownEachArgs).toEqual([[givenSuiteData, 1], [givenSuiteData, 2]]);
+        // AND teardown receives suite state only
+        expect(actualTeardownArg).toBe(givenSuiteData);
+    });
+
+    test("should pass async setup return value during warmup iterations when warmup is configured", async () => {
+        // GIVEN a promise with async suite-level setup and per-iteration setupEach, with warmup
+        const givenDuration = 10;
+        const givenIterations = 2;
+        const givenWarmup = 2;
+        const givenSuiteState = "foo-async-suite";
+        mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+        let givenIterCounter = 0;
+        const actualCallbackArgs: unknown[][] = [];
+
+        // WHEN asserting toResolveWithinQuantile with warmup
+        await expect(async (suiteState: unknown, iterState: unknown) => {
+            actualCallbackArgs.push([suiteState, iterState]);
+        }).toResolveWithinQuantile(givenDuration, {
+            iterations: givenIterations, quantile: 50, warmup: givenWarmup,
+            setup: async () => givenSuiteState,
+            setupEach: async () => ++givenIterCounter,
+        });
+
+        // THEN warmup (2) + measured (2) = 4 calls, all receive suite state and fresh iter state
+        expect(actualCallbackArgs).toEqual([
+            [givenSuiteState, 1], [givenSuiteState, 2], [givenSuiteState, 3], [givenSuiteState, 4],
+        ]);
+    });
+
 });
 
 describe("Benchmark log interpretability annotations", () => {
@@ -1221,6 +2400,34 @@ describe("Input validation", () => {
                 expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, outliers: 'invalid' as 'remove' | 'keep'});
             }).toThrowError("jest-performance-matchers: outliers must be 'remove' or 'keep', received 'invalid'");
         });
+
+        test("should throw when setup is not a function", () => {
+            expect(() => {
+                // @ts-expect-error - intentionally passing invalid setup for testing
+                expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, setup: "not a function"});
+            }).toThrowError("jest-performance-matchers: setup must be a function if provided, received string");
+        });
+
+        test("should throw when setup is null", () => {
+            expect(() => {
+                // @ts-expect-error - intentionally passing invalid setup for testing
+                expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, setup: null});
+            }).toThrowError("jest-performance-matchers: setup must be a function if provided, received object");
+        });
+
+        test("should throw when teardown is not a function", () => {
+            expect(() => {
+                // @ts-expect-error - intentionally passing invalid teardown for testing
+                expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, teardown: 42});
+            }).toThrowError("jest-performance-matchers: teardown must be a function if provided, received number");
+        });
+
+        test("should throw when teardown is null", () => {
+            expect(() => {
+                // @ts-expect-error - intentionally passing invalid teardown for testing
+                expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, teardown: null});
+            }).toThrowError("jest-performance-matchers: teardown must be a function if provided, received object");
+        });
     });
 
     describe("toResolveWithinQuantile", () => {
@@ -1242,6 +2449,20 @@ describe("Input validation", () => {
             await expect(async () => {
                 await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, {iterations: -1, quantile: 95});
             }).rejects.toThrowError("jest-performance-matchers: iterations must be a positive integer, received -1");
+        });
+
+        test("should throw when setup is not a function", async () => {
+            await expect(async () => {
+                // @ts-expect-error - intentionally passing invalid setup for testing
+                await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, {iterations: 5, quantile: 95, setup: "not a function"});
+            }).rejects.toThrowError("jest-performance-matchers: setup must be a function if provided, received string");
+        });
+
+        test("should throw when teardown is not a function", async () => {
+            await expect(async () => {
+                // @ts-expect-error - intentionally passing invalid teardown for testing
+                await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, {iterations: 5, quantile: 95, teardown: 42});
+            }).rejects.toThrowError("jest-performance-matchers: teardown must be a function if provided, received number");
         });
     });
 });


### PR DESCRIPTION
## Summary

- Add optional `setup` and `teardown` callbacks to all four matchers
- **Single-run matchers** (`toCompleteWithin`, `toResolveWithin`): `setup`/`teardown` run once; setup return value passed to callback and teardown
- **Quantile matchers** (`toCompleteWithinQuantile`, `toResolveWithinQuantile`): two-level hooks:
  - `setup`/`teardown` — run **once** before/after all iterations (suite-level state)
  - `setupEach`/`teardownEach` — run **per iteration** (including warmup), not timed
- Setup returns `T` → passed to `setupEach`, callback, `teardownEach`, and `teardown`
- `setupEach` returns `U` → passed (with `T`) to callback and `teardownEach`
- Method-level generics (`<T, U>`) on `Matchers` interface for type inference
- Async matchers accept Promise-returning hooks
- Errors in any hook propagate immediately (fatal)
- Stats block shows `setup/teardown active` hint when any hook is active

Closes #30

## Test plan

- [ ] 269 tests pass, 100% statement + branch coverage
- [ ] Setup called once, teardown called once (sync + async)
- [ ] setupEach/teardownEach called per iteration (including warmup)
- [ ] Full data flow: setup→setupEach→callback→teardownEach→teardown with correct args
- [ ] Warmup iterations receive both suite state and fresh iter state
- [ ] Undefined passed for missing hooks
- [ ] Call order: setup(once) → setupEach → hrtime → callback → hrtime → teardownEach → teardown(once)
- [ ] Error propagation: setup, teardown, setupEach, teardownEach — sync throw + async rejection
- [ ] Stats block hint present with any hook, absent without
- [ ] Validation: non-function values rejected for all four hooks
- [ ] Single-run matchers: setup/teardown return value threading unchanged
- [ ] Lint: 0 errors, Build: compiles cleanly