### PR TITLE
feat: add error rate tolerance option to quantile matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ expect(() => {
 expect(() => {
     sortArray(data);
 }).toCompleteWithinQuantile(10, { iterations: 100, quantile: 95, warmup: 5, outliers: 'remove' });
+
+// With error tolerance — tolerate up to 5% of iterations throwing
+expect(() => {
+    processUnstableInput(data);
+}).toCompleteWithinQuantile(10, { iterations: 200, quantile: 95, allowedErrorRate: 0.05 });
 ```
 
 ### `.toResolveWithin(ms, options?)`
@@ -205,6 +210,11 @@ await expect(async () => {
 await expect(async () => {
     await fetchData();
 }).toResolveWithinQuantile(100, { iterations: 50, quantile: 90, outliers: 'remove' });
+
+// With error tolerance — tolerate up to 2% of iterations failing (e.g., transient network errors)
+await expect(async () => {
+    await handleRequest(mockReq);
+}).toResolveWithinQuantile(100, { iterations: 200, quantile: 95, allowedErrorRate: 0.02 });
 ```
 
 ### Quantile options reference
@@ -219,6 +229,7 @@ await expect(async () => {
 | `teardown` | `(suiteState: T) => void` | No | Called **once** after all iterations. Receives the `setup` return value. Errors are fatal |
 | `setupEach` | `(suiteState: T) => U` | No | Called before **each** iteration (including warmup), not timed. Receives the `setup` return value; its own return value is passed to the callback and `teardownEach`. Errors are fatal |
 | `teardownEach` | `(suiteState: T, iterState: U) => void` | No | Called after **each** iteration (including warmup), not timed. Receives both `setup` and `setupEach` return values. Errors are fatal |
+| `allowedErrorRate` | `number` | No | Fraction of iterations allowed to throw (0–1, default: `0`). Failed iterations are excluded from timing stats. If the actual error rate exceeds this threshold, the matcher fails. Setup/teardown errors are always fatal |
 
 > **Note:** For async matchers (`toResolveWithinQuantile`), `setup` and `setupEach` may return a `Promise` (the resolved value is forwarded), and `teardown`/`teardownEach` may return a `Promise`.
 

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -104,12 +104,58 @@ export function classifySampleAdequacy(n: number): Tag {
  * exceeds the user's threshold — flagging a potential budget overrun even
  * when the quantile assertion passes.
  */
-export function generateInterpretation(stats: Stats, expectedDuration?: number): string {
+function interpretPoorCV(rmeTag: Tag, cvTag: Tag, madTag: Tag | null, context: 'approximate' | 'precise'): string {
+    const madSuffix = madTag !== null ? `, MAD: ${formatTag(madTag)}` : '';
+    if (madTag !== null && madTag.label !== 'POOR') {
+        const action = context === 'approximate'
+            ? 'enable outlier removal and increase iterations'
+            : "enable outlier removal via { outliers: 'remove' }";
+        return `mean is ${context === 'approximate' ? 'approximate and' : 'precise but'} outliers are inflating variance (RME: ${formatTag(rmeTag)}, CV: ${formatTag(cvTag)}, MAD: ${formatTag(madTag)}) — ${action}`;
+    }
+    const action = context === 'approximate'
+        ? 'increase iterations and investigate environment stability'
+        : 'investigate noise sources (GC, I/O, scheduling)';
+    return `mean is ${context === 'approximate' ? 'approximate and' : 'precise but'} ${context === 'approximate' ? 'most runs vary widely' : 'runs are genuinely inconsistent'} (RME: ${formatTag(rmeTag)}, CV: ${formatTag(cvTag)}${madSuffix}) — ${action}`;
+}
+
+function classifyReliability(rme: Tag, cv: Tag, mad: Tag | null, sample: Tag): string {
+    const remedy = 'try increasing iterations, adding warmup, or enabling outlier removal';
+
+    if (rme.label === 'POOR') {
+        const sampleNote = sample.label !== 'GOOD' ? ` with ${sample.label} sample size` : '';
+        return `mean is not reliable (RME: ${formatTag(rme)}, CV: ${formatTag(cv)})${sampleNote}. ${remedy}`;
+    }
+    if (rme.label === 'FAIR' && cv.label === 'POOR') {
+        return interpretPoorCV(rme, cv, mad, 'approximate');
+    }
+    if (rme.label === 'FAIR') {
+        return `results are usable for rough comparison (RME: ${formatTag(rme)}, CV: ${formatTag(cv)}) — increase iterations for tighter estimates`;
+    }
+    if (cv.label === 'POOR') {
+        return interpretPoorCV(rme, cv, mad, 'precise');
+    }
+    if (cv.label === 'FAIR') {
+        return `results are reliable (RME: ${formatTag(rme)}, CV: ${formatTag(cv)}) — moderate run-to-run variance is expected`;
+    }
+    return `results are precise and consistent (RME: ${formatTag(rme)}, CV: ${formatTag(cv)}) — safe for regression detection`;
+}
+
+function appendCICheck(message: string, ci: [number, number], expectedDuration: number): string {
+    const [lower, upper] = ci;
+    if (lower > expectedDuration) {
+        return message + `. CI range [${lower.toFixed(2)}, ${upper.toFixed(2)}]ms is entirely above your ${expectedDuration}ms threshold — the code is almost certainly too slow`;
+    }
+    if (upper > expectedDuration) {
+        return message + `. CI upper bound (${upper.toFixed(2)}ms) exceeds your ${expectedDuration}ms threshold — the true mean likely exceeds your budget, consider optimizing the code or raising the threshold`;
+    }
+    return message + `. CI range [${lower.toFixed(2)}, ${upper.toFixed(2)}]ms is within your ${expectedDuration}ms threshold — the mean is safely within budget`;
+}
+
+export function generateInterpretation(stats: Stats, expectedDuration?: number, errorInfo?: { errorCount: number; totalIterations: number; allowedRate: number }): string {
     const rme = classifyRME(stats.relativeMarginOfError);
     const cv = classifyCV(stats.coefficientOfVariation);
     const mad = classifyMAD(stats.mad, stats.median);
     const sample = classifySampleAdequacy(stats.n);
-    const remedy = 'try increasing iterations, adding warmup, or enabling outlier removal';
 
     if (stats.confidenceInterval === null) {
         return 'results are unreliable — insufficient data for statistical analysis. Add more iterations to enable confidence intervals';
@@ -118,41 +164,14 @@ export function generateInterpretation(stats: Stats, expectedDuration?: number):
         return 'relative error cannot be computed (mean ≈ 0) — RME and CV are unavailable when the mean is zero';
     }
 
-    let message: string;
-
-    if (rme.label === 'POOR') {
-        const sampleNote = sample.label !== 'GOOD' ? ` with ${sample.label} sample size` : '';
-        message = `mean is not reliable (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)})${sampleNote}. ${remedy}`;
-    } else if (rme.label === 'FAIR' && cv!.label === 'POOR') {
-        if (mad !== null && mad.label !== 'POOR') {
-            message = `mean is approximate and outliers are inflating variance (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}, MAD: ${formatTag(mad)}) — enable outlier removal and increase iterations`;
-        } else {
-            message = `mean is approximate and most runs vary widely (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}${mad !== null ? `, MAD: ${formatTag(mad)}` : ''}) — increase iterations and investigate environment stability`;
-        }
-    } else if (rme.label === 'FAIR') {
-        message = `results are usable for rough comparison (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}) — increase iterations for tighter estimates`;
-    } else if (cv!.label === 'POOR') {
-        if (mad !== null && mad.label !== 'POOR') {
-            message = `mean is precise but outliers are inflating variance (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}, MAD: ${formatTag(mad)}) — enable outlier removal via { outliers: 'remove' }`;
-        } else {
-            message = `mean is precise but runs are genuinely inconsistent (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}${mad !== null ? `, MAD: ${formatTag(mad)}` : ''}) — investigate noise sources (GC, I/O, scheduling)`;
-        }
-    } else if (cv!.label === 'FAIR') {
-        message = `results are reliable (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}) — moderate run-to-run variance is expected`;
-    } else {
-        message = `results are precise and consistent (RME: ${formatTag(rme)}, CV: ${formatTag(cv!)}) — safe for regression detection`;
-    }
+    let message = classifyReliability(rme, cv!, mad, sample);
 
     if (expectedDuration !== undefined && stats.confidenceInterval !== null) {
-        const lower = stats.confidenceInterval[0];
-        const upper = stats.confidenceInterval[1];
-        if (lower > expectedDuration) {
-            message += `. CI range [${lower.toFixed(2)}, ${upper.toFixed(2)}]ms is entirely above your ${expectedDuration}ms threshold — the code is almost certainly too slow`;
-        } else if (upper > expectedDuration) {
-            message += `. CI upper bound (${upper.toFixed(2)}ms) exceeds your ${expectedDuration}ms threshold — the true mean likely exceeds your budget, consider optimizing the code or raising the threshold`;
-        } else {
-            message += `. CI range [${lower.toFixed(2)}, ${upper.toFixed(2)}]ms is within your ${expectedDuration}ms threshold — the mean is safely within budget`;
-        }
+        message = appendCICheck(message, stats.confidenceInterval, expectedDuration);
+    }
+
+    if (errorInfo !== undefined && errorInfo.errorCount > 0) {
+        message += `. Note: ${errorInfo.errorCount} of ${errorInfo.totalIterations} iterations were excluded due to errors — stats reflect successful runs only`;
     }
 
     return message;

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ function validateSetupTeardown(options?: { setup?: unknown, teardown?: unknown, 
     }
 }
 
-function validateQuantileOptions(options: { iterations: number, quantile: number, warmup?: number, outliers?: 'remove' | 'keep', setup?: unknown, teardown?: unknown, setupEach?: unknown, teardownEach?: unknown }): void {
+function validateQuantileOptions(options: { iterations: number, quantile: number, warmup?: number, outliers?: 'remove' | 'keep', setup?: unknown, teardown?: unknown, setupEach?: unknown, teardownEach?: unknown, allowedErrorRate?: number }): void {
     if (!options || typeof options !== 'object') {
         throw new Error('jest-performance-matchers: options must be an object with iterations and quantile');
     }
@@ -51,6 +51,11 @@ function validateQuantileOptions(options: { iterations: number, quantile: number
     }
     if (options.outliers !== undefined && options.outliers !== 'remove' && options.outliers !== 'keep') {
         throw new Error(`jest-performance-matchers: outliers must be 'remove' or 'keep', received '${options.outliers}'`);
+    }
+    if (options.allowedErrorRate !== undefined) {
+        if (typeof options.allowedErrorRate !== 'number' || !Number.isFinite(options.allowedErrorRate) || options.allowedErrorRate < 0 || options.allowedErrorRate > 1) {
+            throw new Error(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${options.allowedErrorRate}`);
+        }
     }
     validateSetupTeardown(options);
 }
@@ -100,6 +105,7 @@ function toCompleteWithinQuantile(callback: (...args: any[]) => unknown, expecte
     teardown?: (suiteState: unknown) => void,
     setupEach?: (suiteState: unknown) => unknown,
     teardownEach?: (suiteState: unknown, iterState: unknown) => void,
+    allowedErrorRate?: number,
 }) {
     validateCallback(callback);
     validateDuration(expectedDurationInMilliseconds);
@@ -112,6 +118,8 @@ function toCompleteWithinQuantile(callback: (...args: any[]) => unknown, expecte
 
     const suiteState = setup ? setup() : undefined;
 
+    const allowedErrorRate = options.allowedErrorRate ?? 0;
+
     try {
         for (let i = 0; i < warmup; i++) {
             const iterState = setupEach ? setupEach(suiteState) : undefined;
@@ -123,6 +131,7 @@ function toCompleteWithinQuantile(callback: (...args: any[]) => unknown, expecte
         }
 
         const durations: number[] = [];
+        let errorCount = 0;
         for (let i = 0; i < count; i++) {
             const iterState = setupEach ? setupEach(suiteState) : undefined;
             try {
@@ -130,15 +139,16 @@ function toCompleteWithinQuantile(callback: (...args: any[]) => unknown, expecte
                 callback(suiteState, iterState);
                 const t1 = nowInMillis();
                 durations.push(t1 - t0);
+            } catch (e) {
+                if (allowedErrorRate === 0) throw e;
+                errorCount++;
             } finally {
                 if (teardownEach) teardownEach(suiteState, iterState);
             }
         }
 
-        const effectiveDurations = options.outliers === 'remove' ? removeOutliers(durations) : durations;
-        const quantileValue = calcQuantile(quantile, effectiveDurations);
         const setupTeardownActive = !!(setup || teardown || setupEach || teardownEach);
-        return assertDurationQuantile(count, quantile, quantileValue, effectiveDurations, expectedDurationInMilliseconds, setupTeardownActive);
+        return processQuantileResults(durations, count, quantile, errorCount, allowedErrorRate, expectedDurationInMilliseconds, setupTeardownActive, options.outliers === 'remove');
     } finally {
         if (teardown) teardown(suiteState);
     }
@@ -188,6 +198,7 @@ async function toResolveWithinQuantile(promise: (...args: any[]) => Promise<unkn
     teardown?: (suiteState: unknown) => void | Promise<void>,
     setupEach?: (suiteState: unknown) => unknown | Promise<unknown>,
     teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>,
+    allowedErrorRate?: number,
 }) {
     validateCallback(promise);
     validateDuration(expectedDurationInMilliseconds);
@@ -199,6 +210,7 @@ async function toResolveWithinQuantile(promise: (...args: any[]) => Promise<unkn
     const { setup, teardown, setupEach, teardownEach } = options;
 
     const suiteState = setup ? await setup() : undefined;
+    const allowedErrorRate = options.allowedErrorRate ?? 0;
 
     try {
         for (let i = 0; i < warmup; i++) {
@@ -211,6 +223,7 @@ async function toResolveWithinQuantile(promise: (...args: any[]) => Promise<unkn
         }
 
         const durations: number[] = [];
+        let errorCount = 0;
         for (let i = 0; i < count; i++) {
             const iterState = setupEach ? await setupEach(suiteState) : undefined;
             try {
@@ -218,25 +231,63 @@ async function toResolveWithinQuantile(promise: (...args: any[]) => Promise<unkn
                 await promise(suiteState, iterState);
                 const t1 = nowInMillis();
                 durations.push(t1 - t0);
+            } catch (e) {
+                if (allowedErrorRate === 0) throw e;
+                errorCount++;
             } finally {
                 if (teardownEach) await teardownEach(suiteState, iterState);
             }
         }
 
-        const effectiveDurations = options.outliers === 'remove' ? removeOutliers(durations) : durations;
-        const quantileValue = calcQuantile(quantile, effectiveDurations);
         const setupTeardownActive = !!(setup || teardown || setupEach || teardownEach);
-        return assertDurationQuantile(count, quantile, quantileValue, effectiveDurations, expectedDurationInMilliseconds, setupTeardownActive);
+        return processQuantileResults(durations, count, quantile, errorCount, allowedErrorRate, expectedDurationInMilliseconds, setupTeardownActive, options.outliers === 'remove');
     } finally {
         if (teardown) await teardown(suiteState);
     }
+}
+
+function processQuantileResults(
+    durations: number[], count: number, quantile: number, errorCount: number, allowedErrorRate: number,
+    expectedDurationInMilliseconds: number, setupTeardownActive: boolean, removeOutliersEnabled: boolean
+): { message: () => string; pass: boolean } {
+    if (durations.length === 0) {
+        return {
+            pass: false,
+            message: () => `all ${count} iterations failed (100% error rate, allowed ${(allowedErrorRate * 100).toFixed(1)}%)`,
+        };
+    }
+
+    const actualErrorRate = errorCount / count;
+    if (actualErrorRate > allowedErrorRate) {
+        return {
+            pass: false,
+            message: () => `error rate ${errorCount}/${count} (${(actualErrorRate * 100).toFixed(1)}%) exceeds allowed ${(allowedErrorRate * 100).toFixed(1)}%`,
+        };
+    }
+
+    const effectiveDurations = removeOutliersEnabled ? removeOutliers(durations) : durations;
+    if (effectiveDurations.length === 0) {
+        return {
+            pass: false,
+            message: () => `all ${durations.length} successful iterations were removed as outliers after error exclusion`,
+        };
+    }
+    const quantileValue = calcQuantile(quantile, effectiveDurations);
+    const errorInfo: ErrorInfo | undefined = errorCount > 0 ? { errorCount, totalIterations: count, allowedRate: allowedErrorRate } : undefined;
+    return assertDurationQuantile(count, quantile, quantileValue, effectiveDurations, expectedDurationInMilliseconds, setupTeardownActive, errorInfo);
 }
 
 function formatStatValue(value: number | null): string {
     return value === null ? 'N/A' : value.toFixed(2);
 }
 
-function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: number, setupTeardownActive?: boolean): string {
+interface ErrorInfo {
+    errorCount: number;
+    totalIterations: number;
+    allowedRate: number;
+}
+
+function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: number, setupTeardownActive?: boolean, errorInfo?: ErrorInfo): string {
     const rmeTag = classifyRME(stats.relativeMarginOfError);
     const cvTag = classifyCV(stats.coefficientOfVariation);
 
@@ -272,8 +323,14 @@ function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: 
         `Distribution: min=${formatStatValue(stats.min)}ms | P25=${formatStatValue(p25)}ms | P50=${formatStatValue(p50)}ms | P75=${formatStatValue(p75)}ms | P90=${formatStatValue(p90)}ms | max=${formatStatValue(stats.max)}ms`,
         `Shape: ${shapeDiag.label} (skewness=${skewnessText}) | ${shapeDiag.sparkline}`,
         `Sample adequacy: ${formatTag(classifySampleAdequacy(stats.n))} (n=${stats.n})`,
-        `Interpretation: ${generateInterpretation(stats, expectedDuration)}`,
+        `Interpretation: ${generateInterpretation(stats, expectedDuration, errorInfo)}`,
     ];
+
+    if (errorInfo !== undefined && errorInfo.errorCount > 0) {
+        const actualRate = (errorInfo.errorCount / errorInfo.totalIterations * 100).toFixed(1);
+        const allowedRate = (errorInfo.allowedRate * 100).toFixed(1);
+        lines.push(`Error rate: ${errorInfo.errorCount}/${errorInfo.totalIterations} (${actualRate}%) [within ${allowedRate}% tolerance]`);
+    }
 
     if (stats.warnings.length > 0) {
         lines.push('Warnings:');
@@ -285,9 +342,9 @@ function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: 
     return lines.join('\n');
 }
 
-function assertDurationQuantile(iterations: number, quantile: number,  quantileValue: number, durations: number[], expectedDurationInMilliseconds: number, setupTeardownActive?: boolean) {
+function assertDurationQuantile(iterations: number, quantile: number,  quantileValue: number, durations: number[], expectedDurationInMilliseconds: number, setupTeardownActive?: boolean, errorInfo?: ErrorInfo) {
     const stats = calcStats(durations);
-    const statsBlock = formatStatsBlock(stats, durations, expectedDurationInMilliseconds, setupTeardownActive);
+    const statsBlock = formatStatsBlock(stats, durations, expectedDurationInMilliseconds, setupTeardownActive, errorInfo);
 
     if (quantileValue <= expectedDurationInMilliseconds) {
         return {
@@ -348,6 +405,7 @@ declare global {
                 teardown?: (suiteState: T) => void,
                 setupEach?: (suiteState: T) => U,
                 teardownEach?: (suiteState: T, iterState: U) => void,
+                allowedErrorRate?: number,
             }): R;
 
             toResolveWithin<T = void>(expectedDurationInMilliseconds: number, options?: {
@@ -364,6 +422,7 @@ declare global {
                 teardown?: (suiteState: T) => void | Promise<void>,
                 setupEach?: (suiteState: T) => U | Promise<U>,
                 teardownEach?: (suiteState: T, iterState: U) => void | Promise<void>,
+                allowedErrorRate?: number,
             }): Promise<R>;
         }
     }

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -525,4 +525,40 @@ describe("generateInterpretation", () => {
         expect(actualResult).toContain(`entirely above your ${givenThreshold}ms threshold`);
         expect(actualResult).toContain('almost certainly too slow');
     });
+
+    test("should append excluded-runs note when errorInfo has errors", () => {
+        // GIVEN stats with valid CI and errorInfo indicating excluded runs
+        const givenStats = buildStats({});
+        const givenErrorInfo = { errorCount: 3, totalIterations: 50, allowedRate: 0.1 };
+
+        // WHEN generating interpretation with errorInfo
+        const actualResult = generateInterpretation(givenStats, undefined, givenErrorInfo);
+
+        // THEN the note about excluded runs is appended
+        expect(actualResult).toContain(`${givenErrorInfo.errorCount} of ${givenErrorInfo.totalIterations} iterations were excluded due to errors`);
+        expect(actualResult).toContain('stats reflect successful runs only');
+    });
+
+    test("should not append excluded-runs note when errorInfo has zero errors", () => {
+        // GIVEN stats with valid CI and errorInfo with zero errors
+        const givenStats = buildStats({});
+        const givenErrorInfo = { errorCount: 0, totalIterations: 50, allowedRate: 0.1 };
+
+        // WHEN generating interpretation with errorInfo
+        const actualResult = generateInterpretation(givenStats, undefined, givenErrorInfo);
+
+        // THEN no excluded-runs note is appended
+        expect(actualResult).not.toContain('iterations were excluded');
+    });
+
+    test("should not append excluded-runs note when errorInfo is undefined", () => {
+        // GIVEN stats with valid CI and no errorInfo
+        const givenStats = buildStats({});
+
+        // WHEN generating interpretation without errorInfo
+        const actualResult = generateInterpretation(givenStats);
+
+        // THEN no excluded-runs note is appended
+        expect(actualResult).not.toContain('iterations were excluded');
+    });
 });

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -9,7 +9,7 @@ function mockFunctionProcessTime(milliseconds: number) {
     mockFunctionProcessTimes([milliseconds]);
 }
 
-function buildStatsBlock(durations: number[], expectedDuration?: number, setupTeardownActive?: boolean): string {
+function buildStatsBlock(durations: number[], expectedDuration?: number, setupTeardownActive?: boolean, errorInfo?: { errorCount: number; totalIterations: number; allowedRate: number }): string {
     const stats = metrics.calcStats(durations);
     const fmt = (v: number | null) => v !== null ? v.toFixed(2) : 'N/A';
 
@@ -48,8 +48,14 @@ function buildStatsBlock(durations: number[], expectedDuration?: number, setupTe
         `Distribution: min=${fmt(stats.min)}ms | P25=${fmt(p25)}ms | P50=${fmt(p50)}ms | P75=${fmt(p75)}ms | P90=${fmt(p90)}ms | max=${fmt(stats.max)}ms`,
         `Shape: ${shapeDiag.label} (skewness=${skewnessText}) | ${shapeDiag.sparkline}`,
         `Sample adequacy: ${formatTag(classifySampleAdequacy(stats.n))} (n=${stats.n})`,
-        `Interpretation: ${generateInterpretation(stats, expectedDuration)}`,
+        `Interpretation: ${generateInterpretation(stats, expectedDuration, errorInfo)}`,
     ];
+
+    if (errorInfo !== undefined && errorInfo.errorCount > 0) {
+        const actualRate = (errorInfo.errorCount / errorInfo.totalIterations * 100).toFixed(1);
+        const allowedRate = (errorInfo.allowedRate * 100).toFixed(1);
+        lines.push(`Error rate: ${errorInfo.errorCount}/${errorInfo.totalIterations} (${actualRate}%) [within ${allowedRate}% tolerance]`);
+    }
 
     if (stats.warnings.length > 0) {
         lines.push('Warnings:');
@@ -1738,6 +1744,489 @@ describe("Setup/teardown options (async)", () => {
 
 });
 
+describe("Error rate tolerance (sync)", () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("should pass the assertion when error rate is within tolerance", () => {
+        // GIVEN a callback that fails 3 of 10 iterations
+        const givenIterations = 10;
+        const givenAllowedErrorRate = 0.5;
+        const givenFailCount = 3;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+
+        // WHEN asserting with allowedErrorRate above the actual failure rate
+        // THEN the assertion passes (30% < 50%)
+        expect((..._args: unknown[]) => {
+            callCount++;
+            if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+        }).toCompleteWithinQuantile(10, {
+            iterations: givenIterations, quantile: 50, allowedErrorRate: givenAllowedErrorRate,
+        });
+    });
+
+    test("should fail the assertion when error rate exceeds tolerance", () => {
+        // GIVEN a callback that fails 6 of 10 iterations
+        const givenIterations = 10;
+        const givenAllowedErrorRate = 0.3;
+        const givenFailCount = 6;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+
+        // WHEN asserting with allowedErrorRate below the actual failure rate
+        // THEN the assertion fails with a descriptive error rate message
+        expect(() => {
+            expect((..._args: unknown[]) => {
+                callCount++;
+                if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+            }).toCompleteWithinQuantile(10, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: givenAllowedErrorRate,
+            });
+        }).toThrowError(/error rate 6\/10 \(60\.0%\) exceeds allowed 30\.0%/);
+    });
+
+    test("should propagate error immediately when allowedErrorRate is not set (default 0)", () => {
+        // GIVEN a callback that always throws and no allowedErrorRate option
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-callback-error");
+
+        // WHEN the callback throws during iteration
+        // THEN the error propagates immediately (backward compatible)
+        expect(() => {
+            expect((..._args: unknown[]) => { throw givenError; }).toCompleteWithinQuantile(10, {
+                iterations: 10, quantile: 50,
+            });
+        }).toThrowError(givenError.message);
+    });
+
+    test("should propagate error immediately when allowedErrorRate is explicitly 0", () => {
+        // GIVEN a callback that always throws with allowedErrorRate explicitly set to 0
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-callback-error");
+
+        // WHEN the callback throws during iteration
+        // THEN the error propagates immediately (same as default)
+        expect(() => {
+            expect((..._args: unknown[]) => { throw givenError; }).toCompleteWithinQuantile(10, {
+                iterations: 10, quantile: 50, allowedErrorRate: 0,
+            });
+        }).toThrowError(givenError.message);
+    });
+
+    test("should fail with all-failed message when every iteration throws", () => {
+        // GIVEN a callback that always throws with maximum error tolerance
+        const givenIterations = 5;
+        const givenAllowedErrorRate = 1.0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+
+        // WHEN all iterations fail
+        // THEN the matcher fails with a descriptive all-failed message
+        expect(() => {
+            expect((..._args: unknown[]) => { throw new Error("foo-always-fails"); }).toCompleteWithinQuantile(10, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: givenAllowedErrorRate,
+            });
+        }).toThrowError(/all 5 iterations failed \(100% error rate, allowed 100\.0%\)/);
+    });
+
+    test("should call teardown when all iterations fail", () => {
+        // GIVEN a callback that always throws and a teardown spy
+        const givenIterations = 5;
+        const givenSetupState = "foo-suite-state";
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+        const givenTeardown = jest.fn();
+
+        // WHEN all iterations fail
+        expect(() => {
+            expect((..._args: unknown[]) => { throw new Error("foo-always-fails"); }).toCompleteWithinQuantile(10, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: 1.0,
+                setup: () => givenSetupState,
+                teardown: givenTeardown,
+            });
+        }).toThrowError(/all 5 iterations failed/);
+
+        // THEN teardown is still called with the setup state
+        expect(givenTeardown).toHaveBeenCalledTimes(1);
+        expect(givenTeardown).toHaveBeenCalledWith(givenSetupState);
+    });
+
+    test("should call teardown when error rate is exceeded", () => {
+        // GIVEN a callback that fails 6 of 10 iterations and a teardown spy
+        const givenIterations = 10;
+        const givenFailCount = 6;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+        const givenTeardown = jest.fn();
+
+        // WHEN the error rate exceeds the threshold
+        expect(() => {
+            expect((..._args: unknown[]) => {
+                callCount++;
+                if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+            }).toCompleteWithinQuantile(10, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: 0.3,
+                setup: () => "foo-state",
+                teardown: givenTeardown,
+            });
+        }).toThrowError(/error rate/);
+
+        // THEN teardown is still called
+        expect(givenTeardown).toHaveBeenCalledTimes(1);
+    });
+
+    test("should propagate setupEach error as fatal when allowedErrorRate is set", () => {
+        // GIVEN a setupEach that throws with error tolerance enabled
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-setupEach-error");
+
+        // WHEN setupEach throws
+        // THEN the error propagates immediately (not counted toward error rate)
+        expect(() => {
+            expect((..._args: unknown[]) => undefined).toCompleteWithinQuantile(10, {
+                iterations: 10, quantile: 50, allowedErrorRate: 0.5,
+                setupEach: () => { throw givenError; },
+            });
+        }).toThrowError(givenError.message);
+    });
+
+    test("should propagate teardownEach error as fatal when allowedErrorRate is set", () => {
+        // GIVEN a teardownEach that throws with error tolerance enabled
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-teardownEach-error");
+
+        // WHEN teardownEach throws
+        // THEN the error propagates immediately (not counted toward error rate)
+        expect(() => {
+            expect((..._args: unknown[]) => undefined).toCompleteWithinQuantile(10, {
+                iterations: 10, quantile: 50, allowedErrorRate: 0.5,
+                teardownEach: () => { throw givenError; },
+            });
+        }).toThrowError(givenError.message);
+    });
+
+    test("should include error rate line in diagnostics when errors occur within tolerance", () => {
+        // GIVEN a callback that fails 2 of 10 iterations within tolerance
+        const givenIterations = 10;
+        const givenFailCount = 2;
+        const givenAllowedErrorRate = 0.5;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+
+        // WHEN the quantile matcher fails (duration exceeds threshold)
+        let actualMessage = '';
+        try {
+            expect((..._args: unknown[]) => {
+                callCount++;
+                if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+            }).toCompleteWithinQuantile(5, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: givenAllowedErrorRate,
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the error rate line appears in the diagnostics
+        const expectedErrorRateLine = 'Error rate: 2/10 (20.0%) [within 50.0% tolerance]';
+        expect(actualMessage).toContain(expectedErrorRateLine);
+    });
+
+    test("should not include error rate line when no errors occur with allowedErrorRate set", () => {
+        // GIVEN a callback that never throws with allowedErrorRate set
+        mockFunctionProcessTimes(Array(5).fill(10));
+
+        // WHEN the assertion passes with no errors
+        let actualMessage = '';
+        try {
+            expect((..._args: unknown[]) => undefined).toCompleteWithinQuantile(5, {
+                iterations: 5, quantile: 50, allowedErrorRate: 0.1,
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN no error rate line appears
+        expect(actualMessage).not.toContain('Error rate:');
+    });
+
+    test("should note excluded runs in interpretation when errors occur", () => {
+        // GIVEN a callback that fails 2 of 10 iterations
+        const givenIterations = 10;
+        const givenFailCount = 2;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+
+        // WHEN the quantile matcher produces diagnostics
+        let actualMessage = '';
+        try {
+            expect((..._args: unknown[]) => {
+                callCount++;
+                if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+            }).toCompleteWithinQuantile(5, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: 0.5,
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the interpretation notes the excluded runs
+        expect(actualMessage).toContain(`${givenFailCount} of ${givenIterations} iterations were excluded due to errors`);
+    });
+
+    test("should compute stats on successful runs only when errors reduce n", () => {
+        // GIVEN a callback that fails 2 of 5 iterations
+        const givenIterations = 5;
+        const givenFailCount = 2;
+        const expectedSuccessfulN = givenIterations - givenFailCount;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+
+        // WHEN the quantile matcher produces diagnostics
+        let actualMessage = '';
+        try {
+            expect((..._args: unknown[]) => {
+                callCount++;
+                if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+            }).toCompleteWithinQuantile(5, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: 0.5,
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN stats reflect only successful runs
+        expect(actualMessage).toContain(`Statistics (n=${expectedSuccessfulN}`);
+    });
+
+    test("should fail when all successful iterations are removed as outliers after error exclusion", () => {
+        // GIVEN a callback that fails 5 of 10 iterations and removeOutliers returns empty
+        const givenIterations = 10;
+        const givenFailCount = 5;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+        jest.spyOn(metrics, 'removeOutliers').mockReturnValue([]);
+
+        // WHEN outlier removal empties the remaining durations
+        // THEN the matcher fails with a descriptive message
+        expect(() => {
+            expect((..._args: unknown[]) => {
+                callCount++;
+                if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+            }).toCompleteWithinQuantile(10, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: 0.6, outliers: 'remove',
+            });
+        }).toThrowError(/all \d+ successful iterations were removed as outliers/);
+    });
+
+    test("should propagate warmup error as fatal when allowedErrorRate is set", () => {
+        // GIVEN a callback that throws during warmup with error tolerance enabled
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-warmup-error");
+        let givenWarmupDone = false;
+
+        // WHEN the callback throws during warmup
+        // THEN the error propagates immediately (warmup errors are always fatal)
+        expect(() => {
+            expect((..._args: unknown[]) => {
+                if (!givenWarmupDone) throw givenError;
+            }).toCompleteWithinQuantile(10, {
+                iterations: 5, quantile: 50, warmup: 1, allowedErrorRate: 0.5,
+            });
+        }).toThrowError(givenError.message);
+    });
+});
+
+describe("Error rate tolerance (async)", () => {
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test("should pass the assertion when error rate is within tolerance", async () => {
+        // GIVEN an async callback that fails 3 of 10 iterations
+        const givenIterations = 10;
+        const givenAllowedErrorRate = 0.5;
+        const givenFailCount = 3;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+
+        // WHEN asserting with allowedErrorRate above the actual failure rate
+        // THEN the assertion passes
+        await expect(async (..._args: unknown[]) => {
+            callCount++;
+            if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+        }).toResolveWithinQuantile(10, {
+            iterations: givenIterations, quantile: 50, allowedErrorRate: givenAllowedErrorRate,
+        });
+    });
+
+    test("should fail the assertion when error rate exceeds tolerance", async () => {
+        // GIVEN an async callback that fails 6 of 10 iterations
+        const givenIterations = 10;
+        const givenAllowedErrorRate = 0.3;
+        const givenFailCount = 6;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+
+        // WHEN asserting with allowedErrorRate below the actual failure rate
+        let actualMessage = '';
+        try {
+            await expect(async (..._args: unknown[]) => {
+                callCount++;
+                if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+            }).toResolveWithinQuantile(10, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: givenAllowedErrorRate,
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the failure message contains the error rate
+        expect(actualMessage).toContain(`error rate ${givenFailCount}/${givenIterations} (60.0%) exceeds allowed 30.0%`);
+    });
+
+    test("should propagate error immediately when allowedErrorRate is not set (default 0)", async () => {
+        // GIVEN an async callback that always throws and no allowedErrorRate option
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-async-callback-error");
+
+        // WHEN the callback throws during iteration
+        // THEN the error propagates immediately
+        await expect(
+            expect(async (..._args: unknown[]) => { throw givenError; }).toResolveWithinQuantile(10, {
+                iterations: 10, quantile: 50,
+            })
+        ).rejects.toThrowError(givenError.message);
+    });
+
+    test("should fail with all-failed message when every iteration throws", async () => {
+        // GIVEN an async callback that always throws with maximum error tolerance
+        const givenIterations = 5;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+
+        // WHEN all iterations fail
+        let actualMessage = '';
+        try {
+            await expect(async (..._args: unknown[]) => { throw new Error("foo-always-fails"); }).toResolveWithinQuantile(10, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: 1.0,
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the failure message indicates all iterations failed
+        expect(actualMessage).toContain(`all ${givenIterations} iterations failed`);
+    });
+
+    test("should fail when all successful iterations are removed as outliers after error exclusion", async () => {
+        // GIVEN an async callback that fails 5 of 10 iterations and removeOutliers returns empty
+        const givenIterations = 10;
+        const givenFailCount = 5;
+        let callCount = 0;
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+        jest.spyOn(metrics, 'removeOutliers').mockReturnValue([]);
+
+        // WHEN outlier removal empties the remaining durations
+        let actualMessage = '';
+        try {
+            await expect(async (..._args: unknown[]) => {
+                callCount++;
+                if (callCount <= givenFailCount) throw new Error("foo-transient-error");
+            }).toResolveWithinQuantile(10, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: 0.6, outliers: 'remove',
+            });
+        } catch (e) {
+            actualMessage = (e as Error).message;
+        }
+
+        // THEN the matcher fails with a descriptive message
+        expect(actualMessage).toContain('successful iterations were removed as outliers');
+    });
+
+    test("should call teardown when all iterations fail", async () => {
+        // GIVEN an async callback that always throws and a teardown spy
+        const givenIterations = 5;
+        const givenSetupState = "foo-suite-state";
+        mockFunctionProcessTimes(Array(givenIterations).fill(10));
+        const givenTeardown = jest.fn();
+
+        // WHEN all iterations fail
+        try {
+            await expect(async (..._args: unknown[]) => { throw new Error("foo-always-fails"); }).toResolveWithinQuantile(10, {
+                iterations: givenIterations, quantile: 50, allowedErrorRate: 1.0,
+                setup: () => givenSetupState,
+                teardown: givenTeardown,
+            });
+        } catch {
+            // expected
+        }
+
+        // THEN teardown is still called with the setup state
+        expect(givenTeardown).toHaveBeenCalledTimes(1);
+        expect(givenTeardown).toHaveBeenCalledWith(givenSetupState);
+    });
+
+    test("should propagate setupEach error as fatal when allowedErrorRate is set", async () => {
+        // GIVEN an async setupEach that rejects with error tolerance enabled
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-async-setupEach-error");
+
+        // WHEN setupEach rejects
+        // THEN the error propagates immediately (not counted toward error rate)
+        await expect(
+            expect(async (..._args: unknown[]) => undefined).toResolveWithinQuantile(10, {
+                iterations: 10, quantile: 50, allowedErrorRate: 0.5,
+                setupEach: async () => { throw givenError; },
+            })
+        ).rejects.toThrowError(givenError.message);
+    });
+
+    test("should propagate teardownEach error as fatal when allowedErrorRate is set", async () => {
+        // GIVEN an async teardownEach that rejects with error tolerance enabled
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-async-teardownEach-error");
+
+        // WHEN teardownEach rejects
+        // THEN the error propagates immediately (not counted toward error rate)
+        await expect(
+            expect(async (..._args: unknown[]) => undefined).toResolveWithinQuantile(10, {
+                iterations: 10, quantile: 50, allowedErrorRate: 0.5,
+                teardownEach: async () => { throw givenError; },
+            })
+        ).rejects.toThrowError(givenError.message);
+    });
+
+    test("should propagate warmup error as fatal when allowedErrorRate is set", async () => {
+        // GIVEN an async callback that throws during warmup with error tolerance enabled
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-async-warmup-error");
+        let givenWarmupDone = false;
+
+        // WHEN the callback throws during warmup
+        // THEN the error propagates immediately (warmup errors are always fatal)
+        await expect(
+            expect(async (..._args: unknown[]) => {
+                if (!givenWarmupDone) throw givenError;
+            }).toResolveWithinQuantile(10, {
+                iterations: 5, quantile: 50, warmup: 1, allowedErrorRate: 0.5,
+            })
+        ).rejects.toThrowError(givenError.message);
+    });
+
+    test("should propagate error immediately when allowedErrorRate is explicitly 0", async () => {
+        // GIVEN an async callback that always throws with allowedErrorRate explicitly set to 0
+        mockFunctionProcessTimes(Array(10).fill(10));
+        const givenError = new Error("foo-async-callback-error");
+
+        // WHEN the callback throws during iteration
+        // THEN the error propagates immediately (same as default)
+        await expect(
+            expect(async (..._args: unknown[]) => { throw givenError; }).toResolveWithinQuantile(10, {
+                iterations: 10, quantile: 50, allowedErrorRate: 0,
+            })
+        ).rejects.toThrowError(givenError.message);
+    });
+});
+
 describe("Benchmark log interpretability annotations", () => {
     beforeEach(() => {
         jest.restoreAllMocks();
@@ -2461,6 +2950,46 @@ describe("Input validation", () => {
                 expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, teardown: null});
             }).toThrowError("jest-performance-matchers: teardown must be a function if provided, received object");
         });
+
+        test("should throw a validation error when allowedErrorRate is negative", () => {
+            // GIVEN a negative allowedErrorRate
+            const givenAllowedErrorRate = -0.1;
+
+            // WHEN asserting with the invalid rate
+            // THEN a descriptive error is thrown
+            expect(() => {
+                expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, allowedErrorRate: givenAllowedErrorRate});
+            }).toThrowError(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${givenAllowedErrorRate}`);
+        });
+
+        test("should throw a validation error when allowedErrorRate exceeds 1", () => {
+            // GIVEN an allowedErrorRate above the maximum
+            const givenAllowedErrorRate = 1.1;
+
+            // WHEN asserting with the invalid rate
+            // THEN a descriptive error is thrown
+            expect(() => {
+                expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, allowedErrorRate: givenAllowedErrorRate});
+            }).toThrowError(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${givenAllowedErrorRate}`);
+        });
+
+        test("should throw a validation error when allowedErrorRate is NaN", () => {
+            // GIVEN NaN as allowedErrorRate
+            // WHEN asserting with the invalid rate
+            // THEN a descriptive error is thrown
+            expect(() => {
+                expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, allowedErrorRate: NaN});
+            }).toThrowError("jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received NaN");
+        });
+
+        test("should throw a validation error when allowedErrorRate is Infinity", () => {
+            // GIVEN Infinity as allowedErrorRate
+            // WHEN asserting with the invalid rate
+            // THEN a descriptive error is thrown
+            expect(() => {
+                expect(() => undefined).toCompleteWithinQuantile(10, {iterations: 5, quantile: 95, allowedErrorRate: Infinity});
+            }).toThrowError("jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received Infinity");
+        });
     });
 
     describe("toResolveWithinQuantile", () => {
@@ -2496,6 +3025,46 @@ describe("Input validation", () => {
                 // @ts-expect-error - intentionally passing invalid teardown for testing
                 await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, {iterations: 5, quantile: 95, teardown: 42});
             }).rejects.toThrowError("jest-performance-matchers: teardown must be a function if provided, received number");
+        });
+
+        test("should throw a validation error when allowedErrorRate is negative", async () => {
+            // GIVEN a negative allowedErrorRate
+            const givenAllowedErrorRate = -0.1;
+
+            // WHEN asserting with the invalid rate
+            // THEN a descriptive error is thrown
+            await expect(async () => {
+                await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, {iterations: 5, quantile: 95, allowedErrorRate: givenAllowedErrorRate});
+            }).rejects.toThrowError(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${givenAllowedErrorRate}`);
+        });
+
+        test("should throw a validation error when allowedErrorRate exceeds 1", async () => {
+            // GIVEN an allowedErrorRate above the maximum
+            const givenAllowedErrorRate = 1.1;
+
+            // WHEN asserting with the invalid rate
+            // THEN a descriptive error is thrown
+            await expect(async () => {
+                await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, {iterations: 5, quantile: 95, allowedErrorRate: givenAllowedErrorRate});
+            }).rejects.toThrowError(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${givenAllowedErrorRate}`);
+        });
+
+        test("should throw a validation error when allowedErrorRate is NaN", async () => {
+            // GIVEN NaN as allowedErrorRate
+            // WHEN asserting with the invalid rate
+            // THEN a descriptive error is thrown
+            await expect(async () => {
+                await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, {iterations: 5, quantile: 95, allowedErrorRate: NaN});
+            }).rejects.toThrowError("jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received NaN");
+        });
+
+        test("should throw a validation error when allowedErrorRate is Infinity", async () => {
+            // GIVEN Infinity as allowedErrorRate
+            // WHEN asserting with the invalid rate
+            // THEN a descriptive error is thrown
+            await expect(async () => {
+                await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, {iterations: 5, quantile: 95, allowedErrorRate: Infinity});
+            }).rejects.toThrowError("jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received Infinity");
         });
     });
 });


### PR DESCRIPTION
## Summary

- Add `allowedErrorRate` option (0-1, default 0) to `toCompleteWithinQuantile` and `toResolveWithinQuantile`
- When `allowedErrorRate > 0`: callback errors are caught, counted, and excluded from timing stats
- When `allowedErrorRate === 0` (default): errors propagate immediately (exact backward compat)
- Setup/teardown/setupEach/teardownEach errors remain fatal (not counted toward error rate)
- Warmup errors remain fatal regardless of allowedErrorRate
- Three early-exit guards: all iterations failed, error rate exceeded, all outlier-removed after errors
- All early returns inside outer `try` block — teardown always runs
- `formatStatsBlock()` shows error rate line when errors occur within tolerance
- `generateInterpretation()` appends note about excluded runs
- README updated: options table, allowedErrorRate description

Closes #33

## Test plan

- [ ] 329 tests pass, 100% statement + branch coverage
- [ ] Within tolerance: errors caught, stats computed on successful runs only
- [ ] Exceeds tolerance: fails with error rate message
- [ ] Default zero: errors propagate immediately (backward compat)
- [ ] All iterations fail: descriptive message, teardown still called
- [ ] setupEach/teardownEach errors: fatal, not counted
- [ ] Warmup errors: fatal regardless of allowedErrorRate
- [ ] Outlier removal after error exclusion: guarded against empty array
- [ ] Diagnostics: error rate line present/absent, interpretation note
- [ ] Validation: negative, >1, NaN, Infinity — sync and async paths
- [ ] Lint: 0 errors, Build: compiles cleanly