### PR TITLE
feat: add toAchieveOpsPerSecond / toResolveAtOpsPerSecond throughput matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
    Assert · Measure · Prove
 ```
 
-Jest matchers for **statistically reliable** performance testing in Node.js. Measure code execution time over multiple iterations, assert on quantiles, **compare two functions via Welch's t-test**, and catch performance regressions in CI — all with zero dependencies.
+Jest matchers for **statistically reliable** performance testing in Node.js. Measure code execution time over multiple iterations, assert on quantiles, **compare two functions via Welch's t-test**, **assert throughput in ops/sec**, and catch performance regressions in CI — all with zero dependencies.
 
 ```ts
 // Ensure your API handler stays fast — P95 under 50ms across 100 runs
@@ -24,6 +24,10 @@ await expect(async () => {
 // Prove your optimized sort is statistically faster than the baseline
 expect(() => quicksort(data))
     .toBeFasterThan(() => bubblesort(data), { iterations: 100, warmup: 5 });
+
+// Assert your parser sustains at least 10,000 ops/sec over a 1-second window
+expect(() => parseJSON(payload))
+    .toAchieveOpsPerSecond(10000, { duration: 1000, warmup: 100 });
 ```
 
 ## What is this for?
@@ -34,6 +38,7 @@ Use `jest-performance-matchers` when you need to:
 - **Detect performance regressions** — catch slowdowns before they reach production
 - **Validate with statistical confidence** — assert on percentiles (P90, P95, P99), not single flaky runs
 - **Compare implementations** — prove one algorithm is statistically faster than another using Welch's t-test
+- **Assert throughput** — verify a function sustains a minimum ops/sec rate over a time window
 
 If you already have Jest tests, adding performance assertions takes one import and one line of code.
 
@@ -46,6 +51,7 @@ If you already have Jest tests, adding performance assertions takes one import a
 | **Outliers** | One GC pause fails the test | IQR-based outlier removal |
 | **Diagnostics** | You get a number | Mean, median, CI, percentiles, shape, sparklines, and actionable guidance |
 | **Comparison** | Run both, compare means, hope for the best | Welch's t-test with p-values, confidence intervals, and effect size |
+| **Throughput** | DIY loop with a timer | Built-in ops/sec measurement with CI and diagnostics |
 | **Warmup** | DIY or forget about it | Built-in warmup iterations |
 | **Statistics** | None built-in | Built-in — mean, CI, quantiles, outlier detection |
 | **Dependencies** | Grows with each need — more code to trust | Zero — nothing to audit, nothing to break |
@@ -58,6 +64,7 @@ If you already have Jest tests, adding performance assertions takes one import a
 - **Statistical rigor** — 95% confidence intervals (Student's t / z), IQR outlier detection, skewness analysis, distribution shape classification, quality tags, sample adequacy labels, and interpretive guidance on failure
 - **Warmup iterations** — exclude JIT compilation and cache warming from measurements
 - **Comparative benchmarking** — Welch's t-test to statistically prove one function is faster than another, with one-sided hypothesis testing and configurable confidence levels
+- **Throughput assertions** — verify functions sustain a minimum ops/sec rate over a time window, with per-operation timing statistics and throughput confidence intervals
 - **Exported utilities** — use `calcStats()`, `calcQuantile()`, `removeOutliers()`, and `welchTTest()` directly in your own code
 
 ## Prerequisites
@@ -121,6 +128,22 @@ await expect(async () => {
 expect(() => {
     transformDataset(records);
 }).toCompleteWithinQuantile(200, { iterations: 30, quantile: 95 });
+```
+
+### Message broker throughput
+
+```ts
+expect(() => {
+    processMessage(nextMessage());
+}).toAchieveOpsPerSecond(10000, { duration: 1000, warmup: 100 });
+```
+
+### Async throughput — HTTP handler
+
+```ts
+await expect(async () => {
+    await handleRequest(mockReq);
+}).toResolveAtOpsPerSecond(500, { duration: 2000, warmup: 50, outliers: 'remove' });
 ```
 
 ### Algorithm comparison
@@ -294,6 +317,93 @@ await expect(async () => await slowQuery(db))
     .not.toResolveFasterThan(async () => await fastQuery(db), { iterations: 50 });
 ```
 
+### `.toAchieveOpsPerSecond(expectedOps, options)`
+
+Assert that a synchronous function achieves at least the expected ops/sec over a time-bounded measurement window. Instead of running a fixed number of iterations, the function runs continuously for the specified duration, and the achieved throughput is compared against your target:
+
+```ts
+// Basic — sustain at least 10,000 ops/sec over a 1-second window
+expect(() => {
+    parseJSON(payload);
+}).toAchieveOpsPerSecond(10000, { duration: 1000 });
+
+// With warmup — exclude JIT compilation and cache warming
+expect(() => {
+    parseJSON(payload);
+}).toAchieveOpsPerSecond(10000, { duration: 1000, warmup: 100 });
+
+// With outlier removal — filter GC pauses before measuring throughput
+expect(() => {
+    parseJSON(payload);
+}).toAchieveOpsPerSecond(10000, { duration: 1000, warmup: 100, outliers: 'remove' });
+
+// Negation — assert a function does NOT sustain the given ops/sec
+expect(() => {
+    heavyComputation();
+}).not.toAchieveOpsPerSecond(1000000, { duration: 1000 });
+
+// With error tolerance — tolerate up to 5% of operations throwing
+expect(() => {
+    processUnstableInput(data);
+}).toAchieveOpsPerSecond(5000, { duration: 1000, allowedErrorRate: 0.05 });
+```
+
+### `.toResolveAtOpsPerSecond(expectedOps, options)`
+
+Assert that an asynchronous function achieves at least the expected ops/sec over a time-bounded measurement window. Same API as `.toAchieveOpsPerSecond`, but for promise-returning functions:
+
+```ts
+// Basic
+await expect(async () => {
+    await processMessage(msg);
+}).toResolveAtOpsPerSecond(500, { duration: 2000 });
+
+// With warmup and outlier removal
+await expect(async () => {
+    await handleRequest(mockReq);
+}).toResolveAtOpsPerSecond(500, { duration: 2000, warmup: 50, outliers: 'remove' });
+
+// Negation
+await expect(async () => {
+    await slowOperation();
+}).not.toResolveAtOpsPerSecond(10000, { duration: 1000 });
+```
+
+### Throughput options reference
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `duration` | `number` | Yes | Time window in milliseconds over which to measure throughput (e.g., `1000` for 1 second) |
+| `warmup` | `number` | No | Warmup iterations to run before measurement (default: `0`). Not counted toward throughput |
+| `outliers` | `'remove' \| 'keep'` | No | Whether to remove IQR-based outliers from per-operation timings before computing throughput (default: `'keep'`) |
+| `setup` | `() => T` | No | Called **once** before all operations. Return value is shared via `setupEach`, callbacks, and `teardown`. Errors are fatal |
+| `teardown` | `(suiteState: T) => void` | No | Called **once** after all operations (in a `finally` block). Receives the `setup` return value. Errors are fatal |
+| `setupEach` | `(suiteState: T) => U` | No | Called before **each operation** (including warmup), not timed. Its return value is passed to the callback and `teardownEach`. Errors are fatal |
+| `teardownEach` | `(suiteState: T, iterState: U) => void` | No | Called after **each operation** (including warmup), not timed. Receives both `setup` and `setupEach` return values. Errors are fatal |
+| `allowedErrorRate` | `number` | No | Fraction of operations allowed to throw (0-1, default: `0`). Failed operations are excluded from timing stats but counted in total ops. Setup/teardown errors are always fatal |
+
+> **Execution model:** The function runs continuously until the `duration` deadline is reached. Each operation is timed individually, and the achieved ops/sec is computed from the total successful operations divided by the duration. Unlike iteration-based matchers, you do not control how many iterations run — the function runs as many times as it can within the time window.
+
+> **Note:** For async matchers (`toResolveAtOpsPerSecond`), `setup` and `setupEach` may return a `Promise`, and `teardown`/`teardownEach` may return a `Promise`.
+
+#### Throughput setup/teardown example
+
+```ts
+// setup runs once (shared), setupEach runs per operation (fresh state each time)
+expect((conn: DbConnection, batch: Row[]) => {
+    insertBatch(conn, batch);
+}).toAchieveOpsPerSecond(1000, {
+    duration: 2000,
+    warmup: 50,
+    setup: (): DbConnection => createDbConnection(),
+    setupEach: (conn: DbConnection): Row[] => generateBatch(100),
+    teardownEach: (conn: DbConnection, batch: Row[]) => { conn.rollback(); },
+    teardown: (conn: DbConnection) => conn.close(),
+});
+```
+
+Setup, teardown, setupEach, and teardownEach time is excluded from measurements. If any throws, the test fails immediately — these are test infrastructure errors, not tolerated failures.
+
 ### Comparative options reference
 
 | Option | Type | Required | Description |
@@ -421,6 +531,36 @@ The diagnostics include:
 - **Interpretation** — single-sentence summary of result reliability based on the RME × CV × MAD matrix
 - **Warnings** — contextual alerts (e.g., small sample size, empty dataset)
 
+### Throughput matcher diagnostics
+
+When a throughput matcher (`toAchieveOpsPerSecond` / `toResolveAtOpsPerSecond`) fails, it outputs rich diagnostics showing the achieved throughput, per-operation timing statistics, and actionable guidance:
+
+```
+expected function to achieve at least 10,000 ops/sec,
+instead it achieved 8,432 ops/sec (84.3% of target)
+
+Throughput: 8,432 ops/sec over 1,000ms (8,432 total operations)
+  CI 95%: [8,105, 8,759] ops/sec
+  Target: 10,000 ops/sec — shortfall of 1,568 ops/sec (15.7%)
+
+Per-operation timing (n=8432): mean=0.119ms, median=0.108ms, stddev=0.042ms, MAD=0.015ms
+  CI 95%: [0.118, 0.120]ms | RME: 0.89% [GOOD <10%] | CV: 0.35 [POOR >0.3]
+  Distribution: min=0.071ms | P25=0.092ms | P50=0.108ms | P75=0.131ms | P90=0.167ms | max=0.891ms
+  Shape: right-skewed (skewness=3.41) | █▃▁▁▁▁▁▁▁▁
+
+Interpretation: throughput is 15.7% below target; a few extreme outlier ops
+  are dragging down throughput — enable outlier removal via { outliers: 'remove' }
+```
+
+The throughput diagnostics include:
+- **Throughput summary** — achieved ops/sec, measurement duration, total operations completed
+- **Throughput CI** — 95% confidence interval for ops/sec, derived by inverting the per-operation timing CI
+- **Target comparison** — shortfall or surplus in ops/sec and as a percentage
+- **Per-operation timing** — mean, median, standard deviation, and MAD for individual operation durations
+- **Timing CI and quality** — confidence interval, RME, and CV with classification tags (same as quantile matchers)
+- **Distribution and shape** — percentiles, skewness, and ASCII sparkline histogram
+- **Interpretation** — actionable guidance based on the shortfall and data quality
+
 ### Comparative matcher diagnostics
 
 When a comparative matcher (`toBeFasterThan` / `toResolveFasterThan`) fails, it outputs diagnostics for both functions and a statistical comparison:
@@ -468,6 +608,16 @@ The comparative diagnostics include:
 - **Use `setupEach`** to provide fresh data for each iteration — prevents mutation in one function from affecting the other
 - **Check practical significance** — a significant p-value (< α) means Function A is statistically faster, but check the percentage difference to decide if it matters in practice
 - **If the CI for the difference includes zero** — the functions may have equivalent performance; increase iterations for more statistical power
+
+### Throughput testing tips
+
+- **Choose a meaningful duration** — use at least 1000ms for stable results; shorter windows increase variance
+- **Add warmup** — warmup iterations stabilize JIT compilation and caches before the timed window begins
+- **Enable outlier removal** (`outliers: 'remove'`) — a few slow operations can significantly drag down average throughput
+- **Use `setupEach`** to provide fresh data per operation — prevents accumulated state from affecting timing
+- **Set realistic targets** — measure your baseline first, then set a threshold with headroom (e.g., 80% of observed throughput)
+- **Account for CI variability** — shared runners may have lower throughput; allow more headroom than local measurements suggest
+- **Check the throughput CI** — if the CI lower bound is below your target, the function may not reliably sustain the required rate
 
 ### How to use each metric
 
@@ -664,7 +814,8 @@ Fields are `null` when there is insufficient data to compute them (e.g., `stddev
 
 1. **Measure multiple runs** — a single execution is noisy; use `iterations` for stable data
 2. **Assert on quantiles** — P95 means "95% of runs were this fast or faster"
-3. **Warm up, then measure** — let JIT and caches stabilize before collecting data
+3. **Assert on throughput** — ops/sec over a time window captures sustained performance, not just single-operation latency
+4. **Warm up, then measure** — let JIT and caches stabilize before collecting data
 
 ## How to Contribute
 

--- a/examples/comparative.test.ts
+++ b/examples/comparative.test.ts
@@ -10,75 +10,113 @@ import '../src/main';
 // --- Basic comparison ---
 
 test('native sort is faster than manual bubble sort', () => {
-  const data = Array.from({length: 1_000}, () => Math.random());
+  // setupEach provides a fresh unsorted array for each iteration (not timed)
+  const setupEach = () => Array.from({length: 1_000}, () => Math.random());
 
-  expect(() => {
-    [...data].sort((a, b) => a - b);
-  }).toBeFasterThan(() => {
-    // Naive bubble sort — intentionally slow
-    const arr = [...data];
+  // Function A: native Array.sort on fresh data
+  const nativeSort = (_suite: unknown, iterData: unknown) => {
+    const arr = iterData as number[];
+    arr.sort((a, b) => a - b);
+  };
+
+  // Function B: naive bubble sort on fresh data (intentionally slow)
+  const bubbleSort = (_suite: unknown, iterData: unknown) => {
+    const arr = iterData as number[];
     for (let i = 0; i < arr.length; i++) {
       for (let j = 0; j < arr.length - i - 1; j++) {
         if (arr[j] > arr[j + 1]) [arr[j], arr[j + 1]] = [arr[j + 1], arr[j]];
       }
     }
-  }, {iterations: 30, warmup: 3});
+  };
+
+  // Assert that native sort is statistically faster over 30 iterations
+  expect(nativeSort).toBeFasterThan(bubbleSort, {iterations: 30, warmup: 3, setupEach});
 });
 
 // --- With outlier removal ---
 
 test('Map lookup is faster than array find (with outlier removal)', () => {
+  // Prepare a Map and an equivalent array for lookup comparison
   const size = 10_000;
   const keys = Array.from({length: size}, (_, i) => `key-${i}`);
   const map = new Map(keys.map((k, i) => [k, i]));
   const arr = keys.map((k, i) => ({key: k, value: i}));
   const target = keys[size - 1];
 
-  expect(() => {
+  // Function A: Map.get (O(1) average)
+  const mapLookup = () => {
     map.get(target);
-  }).toBeFasterThan(() => {
+  };
+
+  // Function B: Array.find (O(n) worst case)
+  const arrayFind = () => {
     arr.find(item => item.key === target);
-  }, {iterations: 50, warmup: 5, outliers: 'remove'});
+  };
+
+  // Assert with outlier removal to filter GC spikes
+  expect(mapLookup).toBeFasterThan(arrayFind, {iterations: 50, warmup: 5, outliers: 'remove'});
 });
 
 // --- With custom confidence ---
 
 test('string concatenation vs template literal (99% confidence)', () => {
+  // Prepare an array of strings to join
   const parts = Array.from({length: 100}, (_, i) => `part-${i}`);
 
-  expect(() => {
+  // Function A: Array.join
+  const joinMethod = () => {
     parts.join('');
-  }).toBeFasterThan(() => {
+  };
+
+  // Function B: manual string concatenation
+  const concatMethod = () => {
     let result = '';
     for (const p of parts) result += p;
     return result;
-  }, {iterations: 100, confidence: 0.99});
+  };
+
+  // Assert at a stricter 99% confidence level
+  expect(joinMethod).toBeFasterThan(concatMethod, {iterations: 100, confidence: 0.99, outliers: 'remove'});
 });
 
 // --- With setupEach for fresh data each iteration ---
 
 test('Set.has is faster than Array.includes with fresh data each iteration', () => {
+  // Prepare shared data structures
   const arr = Array.from({length: 10_000}, (_, i) => i);
   const set = new Set(arr);
 
-  expect(() => {
+  // Function A: Set.has (O(1) average)
+  const setLookup = () => {
     set.has(arr[arr.length - 1]);
-  }).toBeFasterThan(() => {
+  };
+
+  // Function B: Array.includes (O(n) worst case)
+  const arrayIncludes = () => {
     arr.includes(arr[arr.length - 1]);
-  }, {iterations: 50, warmup: 5});
+  };
+
+  // Assert that Set.has is statistically faster
+  expect(setLookup).toBeFasterThan(arrayIncludes, {iterations: 50, warmup: 5});
 });
 
 // --- Negation: proving two functions have similar performance ---
 
 test('two identical implementations are NOT significantly different', () => {
+  // Prepare shared dataset
   const data = Array.from({length: 1_000}, () => Math.random());
 
-  // Same operation — there should be no significant difference
-  expect(() => {
+  // Both functions perform the same operation
+  const implA = () => {
     data.reduce((sum, x) => sum + x, 0);
-  }).not.toBeFasterThan(() => {
+  };
+
+  const implB = () => {
     data.reduce((sum, x) => sum + x, 0);
-  }, {iterations: 30});
+  };
+
+  // Assert that there is no significant speed difference
+  expect(implA).not.toBeFasterThan(implB, {iterations: 30});
 });
 
 // --- Asynchronous comparison ---
@@ -86,15 +124,20 @@ test('two identical implementations are NOT significantly different', () => {
 test('cached promise is faster than uncached', async () => {
   const cache = new Map<string, number>();
 
-  await expect(async () => {
-    // Cached — instant lookup
+  // Function A: cached lookup (instant)
+  const cachedLookup = async () => {
     if (!cache.has('key')) cache.set('key', 42);
     return cache.get('key');
-  }).toResolveFasterThan(async () => {
-    // Uncached — simulates a slow async operation
+  };
+
+  // Function B: uncached async operation (simulates slow I/O)
+  const uncachedLookup = async () => {
     await new Promise(resolve => setTimeout(resolve, 1));
     return 42;
-  }, {iterations: 20, warmup: 3});
+  };
+
+  // Assert that the cached path is statistically faster
+  await expect(cachedLookup).toResolveFasterThan(uncachedLookup, {iterations: 20, warmup: 3});
 });
 
 // --- With error tolerance ---
@@ -102,13 +145,20 @@ test('cached promise is faster than uncached', async () => {
 test('stable function is faster than flaky function (tolerating 10% errors)', () => {
   let flakyCount = 0;
 
-  expect(() => {
+  // Function A: stable, small sort
+  const stableSort = () => {
     const data = Array.from({length: 100}, () => Math.random());
     data.sort((a, b) => a - b);
-  }).toBeFasterThan(() => {
+  };
+
+  // Function B: flaky, larger sort that occasionally throws
+  const flakySort = () => {
     flakyCount++;
     if (flakyCount % 10 === 0) throw new Error('transient failure');
     const data = Array.from({length: 500}, () => Math.random());
     data.sort((a, b) => a - b);
-  }, {iterations: 50, allowedErrorRate: 0.15});
+  };
+
+  // Assert while tolerating up to 15% errors from the flaky function
+  expect(stableSort).toBeFasterThan(flakySort, {iterations: 50, allowedErrorRate: 0.15});
 });

--- a/examples/quantile.test.ts
+++ b/examples/quantile.test.ts
@@ -10,16 +10,20 @@ import '../src/main';
 // --- Basic quantile assertions ---
 
 test('array sort P95 under 20ms across 50 runs', () => {
+  // Prepare a dataset to sort (copied each iteration to avoid in-place mutation bias)
   const data = Array.from({length: 10_000}, () => Math.random());
 
+  // Assert that 95% of 50 runs complete within 20ms
   expect(() => {
     [...data].sort((a, b) => a - b);
   }).toCompleteWithinQuantile(20, {iterations: 50, quantile: 95});
 });
 
 test('JSON parse P90 under 5ms across 100 runs', () => {
+  // Prepare a JSON payload to parse
   const json = JSON.stringify({items: Array.from({length: 200}, (_, i) => ({id: i}))});
 
+  // Assert that 90% of 100 runs complete within 5ms
   expect(() => {
     JSON.parse(json);
   }).toCompleteWithinQuantile(5, {iterations: 100, quantile: 90});
@@ -28,9 +32,11 @@ test('JSON parse P90 under 5ms across 100 runs', () => {
 // --- With warmup ---
 
 test('regex match P95 under 10ms with warmup for JIT compilation', () => {
+  // Prepare the regex pattern and test input
   const pattern = /(\w+\.)+\w+@(\w+\.)+\w+/;
   const input = 'user.name@example.com';
 
+  // Assert P95 with 5 warmup iterations to stabilize JIT
   expect(() => {
     pattern.test(input);
   }).toCompleteWithinQuantile(10, {iterations: 100, quantile: 95, warmup: 5});
@@ -39,8 +45,10 @@ test('regex match P95 under 10ms with warmup for JIT compilation', () => {
 // --- With outlier removal ---
 
 test('map/reduce P95 under 15ms with outlier removal for GC pauses', () => {
+  // Prepare the dataset
   const data = Array.from({length: 5_000}, (_, i) => i);
 
+  // Assert P95 with Tukey IQR outlier removal to filter GC spikes
   expect(() => {
     data.map(x => x * 2).reduce((sum, x) => sum + x, 0);
   }).toCompleteWithinQuantile(15, {iterations: 100, quantile: 95, outliers: 'remove'});
@@ -49,14 +57,17 @@ test('map/reduce P95 under 15ms with outlier removal for GC pauses', () => {
 // --- With setup/teardown ---
 
 test('sorting fresh data each iteration, P95 under 30ms', () => {
+  // setupEach provides a fresh unsorted array for each iteration (not timed)
+  const setupEach = () => Array.from({length: 10_000}, () => Math.random());
+
+  // Assert P95 when sorting fresh data each time
   expect((_suiteState: unknown, data: unknown) => {
     (data as number[]).sort((a, b) => a - b);
   }).toCompleteWithinQuantile(30, {
     iterations: 50,
     quantile: 95,
     warmup: 3,
-    // setupEach provides a fresh unsorted copy for each iteration
-    setupEach: () => Array.from({length: 10_000}, () => Math.random()),
+    setupEach,
   });
 });
 
@@ -65,10 +76,11 @@ test('sorting fresh data each iteration, P95 under 30ms', () => {
 test('flaky operation P95 under 50ms, tolerating 5% failures', () => {
   let callCount = 0;
 
+  // Assert P95 while tolerating up to 5% transient failures
   expect(() => {
     callCount++;
-    // Simulate a 3% failure rate
     if (callCount % 33 === 0) throw new Error('transient failure');
+
     const data = Array.from({length: 1_000}, () => Math.random());
     data.sort((a, b) => a - b);
   }).toCompleteWithinQuantile(50, {
@@ -81,6 +93,7 @@ test('flaky operation P95 under 50ms, tolerating 5% failures', () => {
 // --- Asynchronous ---
 
 test('async operation P90 under 100ms across 30 runs', async () => {
+  // Assert that an async delay meets P90 within the time budget
   await expect(async () => {
     await new Promise(resolve => setTimeout(resolve, 1));
   }).toResolveWithinQuantile(100, {iterations: 30, quantile: 90, warmup: 3});

--- a/examples/single-run.test.ts
+++ b/examples/single-run.test.ts
@@ -9,23 +9,28 @@ import '../src/main';
 // --- Synchronous ---
 
 test('array sort completes within 50ms', () => {
+  // Prepare a dataset to sort
+  const data = Array.from({length: 10_000}, () => Math.random());
+
+  // Assert that sorting completes within the time budget
   expect(() => {
-    const data = Array.from({length: 10_000}, () => Math.random());
     data.sort((a, b) => a - b);
   }).toCompleteWithin(50);
 });
 
 test('JSON parse completes within 10ms', () => {
+  // Prepare a JSON payload to parse
   const json = JSON.stringify({users: Array.from({length: 100}, (_, i) => ({id: i, name: `user-${i}`}))});
 
+  // Assert that parsing completes within the time budget
   expect(() => {
     JSON.parse(json);
   }).toCompleteWithin(10);
 });
 
 test('heavy computation does NOT complete within 1ms', () => {
+  // Assert that a CPU-intensive loop exceeds the 1ms budget
   expect(() => {
-    // Intentionally slow — summing a large array
     let sum = 0;
     for (let i = 0; i < 1_000_000; i++) sum += Math.sqrt(i);
     return sum;
@@ -35,25 +40,27 @@ test('heavy computation does NOT complete within 1ms', () => {
 // --- With setup/teardown ---
 
 test('sorting pre-generated data completes within 20ms', () => {
+  // Setup generates the data (not timed)
+  const setup = () => Array.from({length: 5_000}, () => Math.random());
+
+  // Assert that sorting the pre-generated data completes within the time budget
   expect((data: number[]) => {
     data.sort((a, b) => a - b);
-  }).toCompleteWithin(20, {
-    // Setup generates the data (not timed); teardown is optional
-    setup: () => Array.from({length: 5_000}, () => Math.random()),
-  });
+  }).toCompleteWithin(20, {setup});
 });
 
 // --- Asynchronous ---
 
 test('setTimeout(0) resolves within 50ms', async () => {
+  // Assert that a minimal async delay resolves within the time budget
   await expect(async () => {
     await new Promise(resolve => setTimeout(resolve, 0));
   }).toResolveWithin(50);
 });
 
 test('async file-like operation resolves within 100ms', async () => {
+  // Assert that a simulated I/O delay resolves within the time budget
   await expect(async () => {
-    // Simulates an async I/O operation
     await new Promise(resolve => setTimeout(resolve, 5));
   }).toResolveWithin(100);
 });

--- a/examples/throughput.test.ts
+++ b/examples/throughput.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Examples: toAchieveOpsPerSecond / toResolveAtOpsPerSecond
+ *
+ * Throughput matchers — assert that a function sustains at least N ops/sec
+ * over a time-bounded measurement window. Unlike iteration-based matchers,
+ * you specify a duration and the matcher runs as many operations as it can.
+ */
+import '../src/main';
+
+// --- Basic throughput assertion ---
+
+test('JSON.parse sustains at least 50,000 ops/sec', () => {
+  // Prepare a JSON payload to parse
+  const json = JSON.stringify({items: Array.from({length: 50}, (_, i) => ({id: i}))});
+
+  // Assert that parsing sustains the target throughput over 1 second
+  expect(() => {
+    JSON.parse(json);
+  }).toAchieveOpsPerSecond(50000, {duration: 1000});
+});
+
+// --- With warmup ---
+
+test('array sort sustains at least 5,000 ops/sec after warmup', () => {
+  // Prepare a dataset to sort (copied each operation to avoid mutation bias)
+  const data = Array.from({length: 1_000}, () => Math.random());
+
+  // Assert throughput with 100 warmup iterations to stabilize JIT
+  expect(() => {
+    [...data].sort((a, b) => a - b);
+  }).toAchieveOpsPerSecond(5000, {duration: 1000, warmup: 100});
+});
+
+// --- With outlier removal ---
+
+test('Map.get sustains high throughput with outlier removal', () => {
+  // Prepare a large Map for lookup
+  const size = 10_000;
+  const keys = Array.from({length: size}, (_, i) => `key-${i}`);
+  const map = new Map(keys.map((k, i) => [k, i]));
+
+  // Assert throughput with Tukey IQR outlier removal to filter GC spikes
+  expect(() => {
+    map.get(keys[size - 1]);
+  }).toAchieveOpsPerSecond(100000, {duration: 1000, warmup: 50, outliers: 'remove'});
+});
+
+// --- With setupEach for fresh data each operation ---
+
+test('sorting fresh arrays at high throughput', () => {
+  // setupEach provides a fresh unsorted array before each operation (not timed)
+  const setupEach = () => Array.from({length: 1_000}, () => Math.random());
+
+  // Assert throughput when sorting fresh data every operation
+  expect((_suiteState: unknown, data: unknown) => {
+    (data as number[]).sort((a, b) => a - b);
+  }).toAchieveOpsPerSecond(1000, {
+    duration: 1000,
+    warmup: 20,
+    setupEach,
+  });
+});
+
+// --- Negation: proving a function does NOT sustain unrealistic throughput ---
+
+test('heavy computation does NOT sustain 1,000,000 ops/sec', () => {
+  // Assert that a CPU-intensive sort cannot sustain an unrealistic target
+  expect(() => {
+    const data = Array.from({length: 1_000}, () => Math.random());
+    data.sort((a, b) => a - b);
+  }).not.toAchieveOpsPerSecond(1000000, {duration: 500});
+});
+
+// --- With error tolerance ---
+
+test('flaky function sustains throughput despite occasional errors', () => {
+  let callCount = 0;
+
+  // Assert throughput while tolerating up to 10% transient failures
+  expect(() => {
+    callCount++;
+    if (callCount % 20 === 0) throw new Error('transient failure');
+
+    const data = Array.from({length: 100}, () => Math.random());
+    data.sort((a, b) => a - b);
+  }).toAchieveOpsPerSecond(1000, {duration: 1000, allowedErrorRate: 0.10});
+});
+
+// --- Asynchronous throughput ---
+
+test('async operation sustains at least 100 ops/sec', async () => {
+  // Assert that an async delay-based operation sustains the target throughput
+  await expect(async () => {
+    await new Promise(resolve => setTimeout(resolve, 1));
+  }).toResolveAtOpsPerSecond(100, {duration: 1000, warmup: 10});
+});
+
+// --- With setup/teardown ---
+
+test('throughput with suite-level setup and per-op setup', () => {
+  // setup runs once before measurement begins (not timed)
+  const setup = () => ({initialized: true});
+
+  // setupEach provides fresh data before each operation (not timed)
+  const setupEach = () => Array.from({length: 100}, () => Math.random());
+
+  // teardown runs once after measurement completes
+  const teardown = () => { /* cleanup resources */ };
+
+  // Assert throughput with both suite-level and per-operation lifecycle hooks
+  expect((_suiteState: unknown, batch: unknown) => {
+    (batch as number[]).reduce((sum, x) => sum + x, 0);
+  }).toAchieveOpsPerSecond(10000, {
+    duration: 1000,
+    warmup: 50,
+    setup,
+    setupEach,
+    teardown,
+  });
+});

--- a/examples/utilities.test.ts
+++ b/examples/utilities.test.ts
@@ -10,25 +10,27 @@ import {calcShapeDiagnostics} from '../src/shape';
 // --- calcStats ---
 
 test('calcStats computes summary statistics for a dataset', () => {
+  // Prepare a realistic timing dataset (31 measurements in milliseconds)
   const durations = [4.2, 5.1, 4.8, 5.5, 4.9, 5.3, 5.0, 4.7, 5.2, 4.6,
     5.4, 4.3, 5.1, 4.9, 5.0, 4.8, 5.3, 4.5, 5.2, 4.7,
     5.1, 4.6, 5.0, 4.9, 5.3, 4.4, 5.2, 4.8, 5.1, 5.0, 4.9];
 
+  // Compute full statistics
   const stats = calcStats(durations);
 
-  // Basic statistics
+  // Verify basic descriptive statistics
   expect(stats.n).toBe(31);
   expect(stats.mean).toBeCloseTo(4.94, 1);
   expect(stats.median).toBeCloseTo(5.0, 1);
   expect(stats.stddev).toBeGreaterThan(0);
 
-  // Confidence interval
-  expect(stats.confidenceMethod).toBe('z'); // n >= 31 uses z-distribution
+  // Verify confidence interval uses z-distribution for n >= 31
+  expect(stats.confidenceMethod).toBe('z');
   expect(stats.confidenceInterval).not.toBeNull();
   expect(stats.confidenceInterval![0]).toBeLessThan(stats.mean!);
   expect(stats.confidenceInterval![1]).toBeGreaterThan(stats.mean!);
 
-  // Quality metrics
+  // Verify quality metrics
   expect(stats.relativeMarginOfError).toBeLessThan(10); // GOOD
   expect(stats.isSmallSample).toBe(false);
 });
@@ -36,8 +38,10 @@ test('calcStats computes summary statistics for a dataset', () => {
 // --- calcQuantile ---
 
 test('calcQuantile computes percentile values', () => {
+  // Prepare sequential data from 1 to 100
   const durations = Array.from({length: 100}, (_, i) => i + 1);
 
+  // Compute common percentiles
   expect(calcQuantile(50, durations)).toBeCloseTo(50.5, 1);  // Median
   expect(calcQuantile(90, durations)).toBeCloseTo(90.1, 1);  // P90
   expect(calcQuantile(95, durations)).toBeCloseTo(95.05, 1); // P95
@@ -47,41 +51,48 @@ test('calcQuantile computes percentile values', () => {
 // --- removeOutliers ---
 
 test('removeOutliers filters extreme values via Tukey fences', () => {
+  // Prepare a dataset with one extreme outlier (50ms among ~5ms values)
   const durations = [5, 5.1, 5.2, 5.0, 4.9, 5.1, 5.0, 4.8, 5.3, 50];
 
+  // Remove outliers using Tukey's fences (Q1 - 1.5*IQR, Q3 + 1.5*IQR)
   const cleaned = removeOutliers(durations);
 
+  // Verify the extreme value is removed and the rest are kept
   expect(cleaned).not.toContain(50);
   expect(cleaned.length).toBe(9);
 });
 
 // --- welchTTest ---
 
-test('welchTTest compares two independent samples', () => {
+test('welchTTest detects a significant difference between two samples', () => {
+  // Prepare two clearly different timing datasets
   const fast = calcStats([5.1, 4.9, 5.0, 5.2, 4.8, 5.1, 5.0, 4.9, 5.2, 5.0]);
   const slow = calcStats([15.1, 14.9, 15.0, 15.2, 14.8, 15.1, 15.0, 14.9, 15.2, 15.0]);
 
+  // Run a one-sided Welch's t-test (H1: fast < slow)
   const result = welchTTest(fast, slow, 0.95);
 
-  // A is clearly faster
+  // Verify the test detects that A is significantly faster
   expect(result.t).toBeLessThan(0);
   expect(result.pValue).toBeLessThan(0.001);
   expect(result.meanDifference).toBeCloseTo(-10, 0);
 
-  // CI for difference excludes zero
+  // Verify the confidence interval for the difference excludes zero
   expect(result.confidenceInterval[1]).toBeLessThan(0);
 });
 
 test('welchTTest returns non-significant result for similar samples', () => {
+  // Prepare two nearly identical timing datasets
   const a = calcStats([10.1, 9.9, 10.0, 10.2, 9.8, 10.1, 10.0, 9.9, 10.2, 10.0]);
   const b = calcStats([10.2, 9.8, 10.1, 10.0, 9.9, 10.0, 10.1, 10.2, 9.9, 10.0]);
 
+  // Run a one-sided Welch's t-test
   const result = welchTTest(a, b, 0.95);
 
-  // No significant difference
+  // Verify the test does NOT find a significant difference
   expect(result.pValue).toBeGreaterThan(0.05);
 
-  // CI for difference includes zero
+  // Verify the confidence interval for the difference includes zero
   expect(result.confidenceInterval[0]).toBeLessThan(0);
   expect(result.confidenceInterval[1]).toBeGreaterThan(0);
 });
@@ -89,16 +100,24 @@ test('welchTTest returns non-significant result for similar samples', () => {
 // --- calcShapeDiagnostics ---
 
 test('calcShapeDiagnostics classifies distribution shape', () => {
-  // Symmetric data
+  // Prepare symmetric data (uniform-like)
   const symmetric = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   const symStats = calcStats(symmetric);
+
+  // Classify the shape
   const symShape = calcShapeDiagnostics(symmetric, symStats.skewness, symStats.stddev);
+
+  // Verify it is classified as symmetric with a sparkline visualization
   expect(symShape.label).toBe('symmetric');
   expect(symShape.sparkline.length).toBeGreaterThan(0);
 
-  // Right-skewed data (many small values, few large values)
+  // Prepare right-skewed data (many small values, few large ones — typical of GC pauses)
   const skewed = [1, 1, 2, 2, 2, 3, 3, 5, 8, 15, 25, 50];
   const skewStats = calcStats(skewed);
+
+  // Classify the shape
   const skewShape = calcShapeDiagnostics(skewed, skewStats.skewness, skewStats.stddev);
+
+  // Verify it is classified as right-skewed
   expect(skewShape.label).toBe('right-skewed');
 });

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -255,3 +255,83 @@ export function formatPValue(p: number): string {
   if (p < 0.0001) return '<0.0001';
   return p.toFixed(4);
 }
+
+/**
+ * Generate a human-readable interpretation of throughput benchmark results.
+ *
+ * Considers throughput vs target, per-op RME, CV, and MAD to diagnose:
+ * | Throughput | RME       | CV   | MAD        | Outcome                                           |
+ * |-----------|-----------|------|------------|---------------------------------------------------|
+ * | Above     | GOOD      | GOOD | —          | Target met, stable and precise                    |
+ * | Above     | any       | POOR | GOOD/FAIR  | Target met, few outlier ops slower, stable overall|
+ * | Above     | any       | POOR | POOR/null  | Target met but genuinely unstable                 |
+ * | Below     | POOR      | any  | —          | Measurement unreliable, need longer duration      |
+ * | Below     | GOOD/FAIR | POOR | GOOD/FAIR  | Below target, outlier spikes — enable outlier removal |
+ * | Below     | GOOD/FAIR | POOR | POOR/null  | Below target, genuinely inconsistent              |
+ * | Below     | GOOD/FAIR | GOOD | —          | Consistently below target — code is too slow      |
+ */
+export function generateThroughputInterpretation(
+  stats: Stats,
+  actualOpsPerSecond: number,
+  expectedOpsPerSecond: number,
+  errorInfo?: { errorCount: number; totalIterations: number; allowedRate: number },
+): string {
+  const rme = classifyRME(stats.relativeMarginOfError);
+  const cv = classifyCV(stats.coefficientOfVariation);
+  const mad = classifyMAD(stats.mad, stats.median);
+
+  if (stats.confidenceInterval === null) {
+    return 'throughput measurement has insufficient data for statistical analysis — increase duration to collect more operations';
+  }
+  if (rme === null) {
+    return 'per-operation timing mean is near zero — throughput statistics cannot be computed reliably';
+  }
+  /* istanbul ignore next -- defensive guard: cv is always non-null when rme is non-null */
+  if (cv === null) {
+    return 'per-operation timing mean is near zero — throughput statistics cannot be computed reliably';
+  }
+
+  const aboveTarget = actualOpsPerSecond >= expectedOpsPerSecond;
+  const pctOfTarget = (actualOpsPerSecond / expectedOpsPerSecond) * 100;
+  const pctDiff = Math.abs(pctOfTarget - 100);
+
+  let message: string;
+  if (aboveTarget) {
+    message = interpretThroughputAbove(rme, cv, mad, pctOfTarget);
+  } else {
+    message = interpretThroughputBelow(rme, cv, mad, pctDiff);
+  }
+
+  if (errorInfo !== undefined && errorInfo.errorCount > 0) {
+    message += `. Note: ${errorInfo.errorCount} of ${errorInfo.totalIterations} operations failed and were excluded — stats reflect successful ops only`;
+  }
+
+  return message;
+}
+
+function interpretThroughputAbove(rme: Tag, cv: Tag, mad: Tag | null, pctOfTarget: number): string {
+  const surplus = pctOfTarget > 100 ? ` (${(pctOfTarget - 100).toFixed(1)}% above target)` : '';
+  if (cv.label === 'POOR') {
+    if (mad !== null && mad.label !== 'POOR') {
+      return `throughput target met${surplus} with stable overall throughput, but a few outlier ops are much slower (CV: ${formatTag(cv)}, MAD: ${formatTag(mad)}) — consider enabling outlier removal for cleaner stats`;
+    }
+    return `throughput target met${surplus} but throughput is genuinely unstable — ops vary widely (CV: ${formatTag(cv)})`;
+  }
+  if (rme.label === 'FAIR') {
+    return `throughput target met${surplus} with stable measurements and moderate precision (RME: ${formatTag(rme)}, CV: ${formatTag(cv)})`;
+  }
+  return `throughput target met${surplus} with stable, precise measurements (RME: ${formatTag(rme)}, CV: ${formatTag(cv)})`;
+}
+
+function interpretThroughputBelow(rme: Tag, cv: Tag, mad: Tag | null, pctBelow: number): string {
+  if (rme.label === 'POOR') {
+    return `throughput is ${pctBelow.toFixed(1)}% below target but measurement is unreliable (RME: ${formatTag(rme)}) — increase duration to collect more operations`;
+  }
+  if (cv.label === 'POOR') {
+    if (mad !== null && mad.label !== 'POOR') {
+      return `throughput is ${pctBelow.toFixed(1)}% below target; a few extreme outlier ops are dragging down throughput (CV: ${formatTag(cv)}, MAD: ${formatTag(mad)}) — enable outlier removal via { outliers: 'remove' }`;
+    }
+    return `throughput is ${pctBelow.toFixed(1)}% below target; ops are genuinely inconsistent (CV: ${formatTag(cv)}) — investigate environment stability`;
+  }
+  return `throughput is consistently ${pctBelow.toFixed(1)}% below target with stable measurements (RME: ${formatTag(rme)}, CV: ${formatTag(cv)}) — the code is genuinely too slow`;
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,6 +8,7 @@ import {
   classifySampleAdequacy,
   generateInterpretation,
   generateComparisonInterpretation,
+  generateThroughputInterpretation,
   formatTag,
   formatPValue,
 } from "./diagnostics";
@@ -271,4 +272,164 @@ export function processComparativeResults(opts: ComparativeResultsOptions): { me
     pass: false,
     message: () => `expected Function A to be faster than Function B,\nbut no statistically significant difference was found (p=${tTest.pValue.toFixed(4)} >= α=${alpha.toFixed(2)})\n\n${statsBlock}`,
   };
+}
+
+export interface ThroughputResultsOptions {
+  durations: number[];
+  totalOps: number;
+  errorCount: number;
+  allowedErrorRate: number;
+  expectedOpsPerSecond: number;
+  duration: number;
+  setupTeardownActive: boolean;
+  removeOutliersEnabled: boolean;
+}
+
+export function processThroughputResults(opts: ThroughputResultsOptions): { message: () => string; pass: boolean } {
+  const {durations, totalOps, errorCount, allowedErrorRate, expectedOpsPerSecond, duration, setupTeardownActive, removeOutliersEnabled} = opts;
+
+  if (durations.length === 0) {
+    return {
+      pass: false,
+      message: () => `all ${totalOps} operations failed (100% error rate, allowed ${(allowedErrorRate * 100).toFixed(1)}%)`,
+    };
+  }
+
+  /* istanbul ignore next -- defensive guard: totalOps is always > 0 when durations is non-empty */
+  const actualErrorRate = totalOps > 0 ? errorCount / totalOps : 0;
+  if (actualErrorRate > allowedErrorRate) {
+    return {
+      pass: false,
+      message: () => `error rate ${errorCount}/${totalOps} (${(actualErrorRate * 100).toFixed(1)}%) exceeds allowed ${(allowedErrorRate * 100).toFixed(1)}%`,
+    };
+  }
+
+  const effectiveDurations = removeOutliersEnabled ? removeOutliers(durations) : durations;
+  /* istanbul ignore next -- defensive guard: Tukey's fences cannot remove all points from a homogeneous dataset */
+  if (effectiveDurations.length === 0) {
+    return {
+      pass: false,
+      message: () => `all ${durations.length} successful operations were removed as outliers after error exclusion`,
+    };
+  }
+
+  const stats = calcStats(effectiveDurations);
+  // Use pre-removal count for throughput: outlier removal cleans per-op stats, not the actual ops completed
+  const actualOpsPerSecond = (durations.length / duration) * 1000;
+  const pass = actualOpsPerSecond >= expectedOpsPerSecond;
+  const pctOfTarget = (actualOpsPerSecond / expectedOpsPerSecond) * 100;
+
+  const errorInfo: ErrorInfo | undefined = errorCount > 0 ? {errorCount, totalIterations: totalOps, allowedRate: allowedErrorRate} : undefined;
+  const statsBlock = formatThroughputStatsBlock({stats, durations: effectiveDurations, actualOpsPerSecond, expectedOpsPerSecond, duration, totalOps: durations.length, setupTeardownActive, errorInfo});
+
+  if (pass) {
+    return {
+      pass: true,
+      message: () => `expected function NOT to achieve at least ${printExpected(Math.round(expectedOpsPerSecond))} ops/sec,\nbut it achieved ${printReceived(Math.round(actualOpsPerSecond))} ops/sec (${pctOfTarget.toFixed(1)}% of target)\n\n${statsBlock}`,
+    };
+  }
+  return {
+    pass: false,
+    message: () => `expected function to achieve at least ${printExpected(Math.round(expectedOpsPerSecond))} ops/sec,\ninstead it achieved ${printReceived(Math.round(actualOpsPerSecond))} ops/sec (${pctOfTarget.toFixed(1)}% of target)\n\n${statsBlock}`,
+  };
+}
+
+interface ThroughputStatsBlockOptions {
+  stats: Stats;
+  durations: number[];
+  actualOpsPerSecond: number;
+  expectedOpsPerSecond: number;
+  duration: number;
+  totalOps: number;
+  setupTeardownActive: boolean;
+  errorInfo?: ErrorInfo;
+}
+
+function formatThroughputStatsBlock(opts: ThroughputStatsBlockOptions): string {
+  const {stats, durations, actualOpsPerSecond, expectedOpsPerSecond, duration, totalOps, setupTeardownActive, errorInfo} = opts;
+
+  // Throughput CI: invert per-op timing CI bounds (inversion flips upper/lower)
+  let throughputCIText: string;
+  if (stats.confidenceInterval === null) {
+    throughputCIText = '  CI 95%: N/A (insufficient data)';
+  } else {
+    const [ciLower, ciUpper] = stats.confidenceInterval;
+    if (ciLower <= 0) {
+      throughputCIText = '  CI 95%: N/A (per-op CI lower bound is non-positive)';
+    } else {
+      const throughputLower = 1000 / ciUpper;
+      const throughputUpper = 1000 / ciLower;
+      throughputCIText = `  CI 95%: [${Math.round(throughputLower)}, ${Math.round(throughputUpper)}] ops/sec`;
+    }
+  }
+
+  // Target comparison
+  const diff = actualOpsPerSecond - expectedOpsPerSecond;
+  const absDiff = Math.abs(diff);
+  const pctDiff = (absDiff / expectedOpsPerSecond) * 100;
+  const targetText = diff >= 0
+    ? `  Target: ${Math.round(expectedOpsPerSecond)} ops/sec — surplus of ${Math.round(absDiff)} ops/sec (${pctDiff.toFixed(1)}%)`
+    : `  Target: ${Math.round(expectedOpsPerSecond)} ops/sec — shortfall of ${Math.round(absDiff)} ops/sec (${pctDiff.toFixed(1)}%)`;
+
+  // Per-op timing section (reuse classification primitives)
+  const rmeTag = classifyRME(stats.relativeMarginOfError);
+  const cvTag = classifyCV(stats.coefficientOfVariation);
+  const madTag = classifyMAD(stats.mad, stats.median);
+
+  const ciText = stats.confidenceInterval === null
+    ? 'N/A (insufficient data)'
+    : `[${stats.confidenceInterval[0].toFixed(2)}, ${stats.confidenceInterval[1].toFixed(2)}]ms`;
+  const rmeText = stats.relativeMarginOfError === null || rmeTag === null
+    ? 'N/A'
+    : `${stats.relativeMarginOfError.toFixed(2)}% [${formatTag(rmeTag)}]`;
+  const cvText = stats.coefficientOfVariation === null || cvTag === null
+    ? 'N/A'
+    : `${stats.coefficientOfVariation.toFixed(2)} [${formatTag(cvTag)}]`;
+
+  const p25 = calcQuantile(25, durations);
+  const p50 = stats.median;
+  const p75 = calcQuantile(75, durations);
+  const p90 = calcQuantile(90, durations);
+
+  const shapeDiag = calcShapeDiagnostics(durations, stats.skewness, stats.stddev);
+  const skewnessText = stats.skewness === null ? 'N/A' : stats.skewness.toFixed(2);
+
+  let madText: string;
+  if (stats.mad === null) {
+    madText = 'N/A';
+  } else {
+    /* istanbul ignore next -- defensive guard: madTag is null only when median is 0, which implies mad is 0, not a realistic throughput scenario */
+    const madTagSuffix = madTag === null ? '' : ` [${formatTag(madTag)}]`;
+    madText = `${stats.mad.toFixed(2)}ms${madTagSuffix}`;
+  }
+
+  const interpretation = generateThroughputInterpretation(stats, actualOpsPerSecond, expectedOpsPerSecond, errorInfo);
+
+  const lines = [
+    `Throughput: ${Math.round(actualOpsPerSecond)} ops/sec over ${Math.round(duration)}ms (${totalOps} total operations)`,
+    throughputCIText,
+    targetText,
+    '',
+    `Per-operation timing (n=${stats.n}${setupTeardownActive ? ', setup/teardown active' : ''}): mean=${formatStatValue(stats.mean)}ms, median=${formatStatValue(stats.median)}ms, stddev=${formatStatValue(stats.stddev)}ms, MAD=${madText}`,
+    `  CI 95%: ${ciText} | RME: ${rmeText} | CV: ${cvText}`,
+    `  Distribution: min=${formatStatValue(stats.min)}ms | P25=${formatStatValue(p25)}ms | P50=${formatStatValue(p50)}ms | P75=${formatStatValue(p75)}ms | P90=${formatStatValue(p90)}ms | max=${formatStatValue(stats.max)}ms`,
+    `  Shape: ${shapeDiag.label} (skewness=${skewnessText}) | ${shapeDiag.sparkline}`,
+    '',
+    `Interpretation: ${interpretation}`,
+  ];
+
+  if (errorInfo !== undefined && errorInfo.errorCount > 0) {
+    const actualRate = (errorInfo.errorCount / errorInfo.totalIterations * 100).toFixed(1);
+    const allowedRate = (errorInfo.allowedRate * 100).toFixed(1);
+    lines.push(`Error rate: ${errorInfo.errorCount}/${errorInfo.totalIterations} (${actualRate}%) [within ${allowedRate}% tolerance]`);
+  }
+
+  if (stats.warnings.length > 0) {
+    lines.push('Warnings:');
+    for (const warning of stats.warnings) {
+      lines.push(`  - ${warning}`);
+    }
+  }
+
+  return lines.join('\n');
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import {expect} from '@jest/globals';
 import {toCompleteWithin, toResolveWithin} from './matchers-single';
 import {toCompleteWithinQuantile, toResolveWithinQuantile} from './matchers-quantile';
 import {toBeFasterThan, toResolveFasterThan} from './matchers-comparative';
+import {toAchieveOpsPerSecond, toResolveAtOpsPerSecond} from './matchers-throughput';
 
 expect.extend({
   toCompleteWithin,
@@ -10,6 +11,8 @@ expect.extend({
   toResolveWithinQuantile,
   toBeFasterThan,
   toResolveFasterThan,
+  toAchieveOpsPerSecond,
+  toResolveAtOpsPerSecond,
 });
 
 declare global {
@@ -65,6 +68,28 @@ declare global {
         iterations: number,
         warmup?: number,
         confidence?: number,
+        outliers?: 'remove' | 'keep',
+        setup?: () => T | Promise<T>,
+        teardown?: (suiteState: T) => void | Promise<void>,
+        setupEach?: (suiteState: T) => U | Promise<U>,
+        teardownEach?: (suiteState: T, iterState: U) => void | Promise<void>,
+        allowedErrorRate?: number,
+      }): Promise<R>;
+
+      toAchieveOpsPerSecond<T = void, U = void>(expectedOpsPerSecond: number, options: {
+        duration: number,
+        warmup?: number,
+        outliers?: 'remove' | 'keep',
+        setup?: () => T,
+        teardown?: (suiteState: T) => void,
+        setupEach?: (suiteState: T) => U,
+        teardownEach?: (suiteState: T, iterState: U) => void,
+        allowedErrorRate?: number,
+      }): R;
+
+      toResolveAtOpsPerSecond<T = void, U = void>(expectedOpsPerSecond: number, options: {
+        duration: number,
+        warmup?: number,
         outliers?: 'remove' | 'keep',
         setup?: () => T | Promise<T>,
         teardown?: (suiteState: T) => void | Promise<void>,

--- a/src/matchers-throughput.ts
+++ b/src/matchers-throughput.ts
@@ -1,0 +1,175 @@
+import {nowInMillis} from "./timing";
+import {validateCallback, validateExpectedOpsPerSecond, validateThroughputOptions} from "./validators";
+import {processThroughputResults} from "./helpers";
+
+interface ThroughputHooks {
+  setup?: () => unknown;
+  teardown?: (suiteState: unknown) => void;
+  setupEach?: (suiteState: unknown) => unknown;
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+type SyncCallback = (...args: any[]) => unknown;
+
+function warmupSync(callback: SyncCallback, warmupCount: number, suiteState: unknown, hooks: ThroughputHooks): void {
+  for (let i = 0; i < warmupCount; i++) {
+    const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
+    try {
+      callback(suiteState, iterState);
+    } finally {
+      if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
+    }
+  }
+}
+
+function measureSyncThroughput(
+  callback: SyncCallback, duration: number, suiteState: unknown,
+  hooks: ThroughputHooks, allowedErrorRate: number,
+): { durations: number[]; errorCount: number } {
+  const durations: number[] = [];
+  let errorCount = 0;
+  const deadline = nowInMillis() + duration;
+
+  while (nowInMillis() < deadline) {
+    const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
+    try {
+      const t0 = nowInMillis();
+      callback(suiteState, iterState);
+      const t1 = nowInMillis();
+      durations.push(t1 - t0);
+    } catch (e) {
+      if (allowedErrorRate === 0) throw e;
+      errorCount++;
+    } finally {
+      if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
+    }
+  }
+
+  return {durations, errorCount};
+}
+
+/**
+ * Assert that a synchronous function achieves at least the expected ops/sec
+ * over a time-bounded measurement window.
+ */
+export function toAchieveOpsPerSecond(callback: SyncCallback, expectedOpsPerSecond: number, options: {
+  duration: number,
+  warmup?: number,
+  outliers?: 'remove' | 'keep',
+  setup?: () => unknown,
+  teardown?: (suiteState: unknown) => void,
+  setupEach?: (suiteState: unknown) => unknown,
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void,
+  allowedErrorRate?: number,
+}) {
+  validateCallback(callback);
+  validateExpectedOpsPerSecond(expectedOpsPerSecond);
+  validateThroughputOptions(options);
+
+  const hooks: ThroughputHooks = options;
+  const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const suiteState = hooks.setup ? hooks.setup() : undefined;
+
+  try {
+    warmupSync(callback, options.warmup ?? 0, suiteState, hooks);
+
+    const {durations, errorCount} = measureSyncThroughput(callback, options.duration, suiteState, hooks, allowedErrorRate);
+    const totalOps = durations.length + errorCount;
+    const setupTeardownActive = !!(hooks.setup || hooks.teardown || hooks.setupEach || hooks.teardownEach);
+
+    return processThroughputResults({
+      durations, totalOps, errorCount, allowedErrorRate,
+      expectedOpsPerSecond, duration: options.duration,
+      setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove',
+    });
+  } finally {
+    if (hooks.teardown) hooks.teardown(suiteState);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+type AsyncCallback = (...args: any[]) => Promise<unknown>;
+
+interface AsyncThroughputHooks {
+  setup?: () => unknown;
+  teardown?: (suiteState: unknown) => void | Promise<void>;
+  setupEach?: (suiteState: unknown) => unknown;
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>;
+}
+
+async function warmupAsync(callback: AsyncCallback, warmupCount: number, suiteState: unknown, hooks: AsyncThroughputHooks): Promise<void> {
+  for (let i = 0; i < warmupCount; i++) {
+    const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
+    try {
+      await callback(suiteState, iterState);
+    } finally {
+      if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
+    }
+  }
+}
+
+async function measureAsyncThroughput(
+  callback: AsyncCallback, duration: number, suiteState: unknown,
+  hooks: AsyncThroughputHooks, allowedErrorRate: number,
+): Promise<{ durations: number[]; errorCount: number }> {
+  const durations: number[] = [];
+  let errorCount = 0;
+  const deadline = nowInMillis() + duration;
+
+  while (nowInMillis() < deadline) {
+    const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
+    try {
+      const t0 = nowInMillis();
+      await callback(suiteState, iterState);
+      const t1 = nowInMillis();
+      durations.push(t1 - t0);
+    } catch (e) {
+      if (allowedErrorRate === 0) throw e;
+      errorCount++;
+    } finally {
+      if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
+    }
+  }
+
+  return {durations, errorCount};
+}
+
+/**
+ * Assert that an asynchronous function achieves at least the expected ops/sec
+ * over a time-bounded measurement window.
+ */
+export async function toResolveAtOpsPerSecond(callback: AsyncCallback, expectedOpsPerSecond: number, options: {
+  duration: number,
+  warmup?: number,
+  outliers?: 'remove' | 'keep',
+  setup?: () => unknown,
+  teardown?: (suiteState: unknown) => void | Promise<void>,
+  setupEach?: (suiteState: unknown) => unknown,
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>,
+  allowedErrorRate?: number,
+}) {
+  validateCallback(callback);
+  validateExpectedOpsPerSecond(expectedOpsPerSecond);
+  validateThroughputOptions(options);
+
+  const hooks: AsyncThroughputHooks = options;
+  const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const suiteState = hooks.setup ? await hooks.setup() : undefined;
+
+  try {
+    await warmupAsync(callback, options.warmup ?? 0, suiteState, hooks);
+
+    const {durations, errorCount} = await measureAsyncThroughput(callback, options.duration, suiteState, hooks, allowedErrorRate);
+    const totalOps = durations.length + errorCount;
+    const setupTeardownActive = !!(hooks.setup || hooks.teardown || hooks.setupEach || hooks.teardownEach);
+
+    return processThroughputResults({
+      durations, totalOps, errorCount, allowedErrorRate,
+      expectedOpsPerSecond, duration: options.duration,
+      setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove',
+    });
+  } finally {
+    if (hooks.teardown) await hooks.teardown(suiteState);
+  }
+}

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -99,3 +99,39 @@ export function validateComparativeOptions(options: {
   }
   validateSetupTeardown(options);
 }
+
+export function validateExpectedOpsPerSecond(expectedOpsPerSecond: number): void {
+  if (typeof expectedOpsPerSecond !== 'number' || !Number.isFinite(expectedOpsPerSecond) || expectedOpsPerSecond <= 0) {
+    throw new Error(`jest-performance-matchers: expected ops/sec must be a positive number, received ${expectedOpsPerSecond}`);
+  }
+}
+
+export function validateThroughputOptions(options: {
+  duration: number,
+  warmup?: number,
+  outliers?: 'remove' | 'keep',
+  setup?: unknown,
+  teardown?: unknown,
+  setupEach?: unknown,
+  teardownEach?: unknown,
+  allowedErrorRate?: number,
+}): void {
+  if (!options || typeof options !== 'object') {
+    throw new Error('jest-performance-matchers: options must be an object with duration');
+  }
+  if (typeof options.duration !== 'number' || !Number.isFinite(options.duration) || options.duration <= 0) {
+    throw new Error(`jest-performance-matchers: duration must be a positive number, received ${options.duration}`);
+  }
+  if (options.warmup !== undefined && (!Number.isInteger(options.warmup) || options.warmup < 0)) {
+    throw new Error(`jest-performance-matchers: warmup must be a non-negative integer, received ${options.warmup}`);
+  }
+  if (options.outliers !== undefined && options.outliers !== 'remove' && options.outliers !== 'keep') {
+    throw new Error(`jest-performance-matchers: outliers must be 'remove' or 'keep', received '${options.outliers}'`);
+  }
+  if (options.allowedErrorRate !== undefined) {
+    if (typeof options.allowedErrorRate !== 'number' || !Number.isFinite(options.allowedErrorRate) || options.allowedErrorRate < 0 || options.allowedErrorRate > 1) {
+      throw new Error(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${options.allowedErrorRate}`);
+    }
+  }
+  validateSetupTeardown(options);
+}

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,6 +1,6 @@
 import {
   classifyRME, classifyCV, classifyMAD, classifySampleAdequacy,
-  generateInterpretation, generateComparisonInterpretation, formatTag, Tag
+  generateInterpretation, generateComparisonInterpretation, generateThroughputInterpretation, formatTag, Tag
 } from '../src/diagnostics';
 import {Stats, WelchTTestResult} from '../src/metrics';
 
@@ -781,5 +781,182 @@ describe("Test generateComparisonInterpretation function", () => {
 
     // THEN it reports significance without throwing a division-by-zero error
     expect(actualResult).toContain('statistically significantly faster');
+  });
+});
+
+describe("generateThroughputInterpretation", () => {
+  function buildThroughputStats(overrides: Partial<Stats>): Stats {
+    return {
+      n: 31, min: 1, max: 10, mean: 5, median: 5, stddev: 1,
+      marginOfError: 0.35, relativeMarginOfError: 7.0,
+      confidenceInterval: [4.65, 5.35],
+      coefficientOfVariation: 0.05, skewness: 0, mad: 1, isSmallSample: false,
+      confidenceMethod: 'z', confidenceCriticalValue: 1.96, warnings: [],
+      ...overrides,
+    };
+  }
+
+  test("should report stable and precise when above target with GOOD RME and GOOD CV", () => {
+    // GIVEN per-operation stats are precise and consistent, with throughput above target
+    const givenStats = buildThroughputStats({relativeMarginOfError: 5, coefficientOfVariation: 0.05});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 200, 100);
+
+    // THEN it reports target met with stable measurements
+    expect(actualResult).toContain('throughput target met');
+    expect(actualResult).toContain('stable, precise measurements');
+  });
+
+  test("should report outlier warning when above target with POOR CV and GOOD MAD", () => {
+    // GIVEN per-operation variance is high but concentrated in a few outliers, with throughput above target
+    const givenStats = buildThroughputStats({coefficientOfVariation: 0.5, mad: 0.3, median: 5});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 200, 100);
+
+    // THEN it reports outlier ops slower
+    expect(actualResult).toContain('few outlier ops are much slower');
+    expect(actualResult).toContain('outlier removal');
+  });
+
+  test("should report genuinely unstable when above target with POOR CV and POOR MAD", () => {
+    // GIVEN per-operation variance is genuinely high across all runs, with throughput above target
+    const givenStats = buildThroughputStats({coefficientOfVariation: 0.5, mad: 2, median: 5});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 200, 100);
+
+    // THEN it reports genuinely unstable
+    expect(actualResult).toContain('genuinely unstable');
+  });
+
+  test("should report genuinely unstable when above target with POOR CV and null MAD", () => {
+    // GIVEN per-operation variance is high with unknown dispersion pattern, and throughput above target
+    const givenStats = buildThroughputStats({coefficientOfVariation: 0.5, mad: null});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 200, 100);
+
+    // THEN it reports genuinely unstable
+    expect(actualResult).toContain('genuinely unstable');
+  });
+
+  test("should report moderate precision when above target with FAIR RME", () => {
+    // GIVEN per-operation stats have moderate precision and low variance, with throughput above target
+    const givenStats = buildThroughputStats({relativeMarginOfError: 15, coefficientOfVariation: 0.05});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 200, 100);
+
+    // THEN it reports moderate precision, not "precise"
+    expect(actualResult).toContain('moderate precision');
+    expect(actualResult).not.toContain('stable, precise');
+  });
+
+  test("should report unreliable measurement when below target with POOR RME", () => {
+    // GIVEN per-operation measurement is unreliable, with throughput below target
+    const givenStats = buildThroughputStats({relativeMarginOfError: 40});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 50, 100);
+
+    // THEN it reports unreliable measurement
+    expect(actualResult).toContain('measurement is unreliable');
+    expect(actualResult).toContain('increase duration');
+  });
+
+  test("should report outlier drag when below target with GOOD RME, POOR CV, and GOOD MAD", () => {
+    // GIVEN per-operation stats are precise but outliers are inflating variance, with throughput below target
+    const givenStats = buildThroughputStats({relativeMarginOfError: 5, coefficientOfVariation: 0.5, mad: 0.3, median: 5});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 50, 100);
+
+    // THEN it reports outlier spikes dragging down throughput
+    expect(actualResult).toContain('extreme outlier ops are dragging down throughput');
+    expect(actualResult).toContain('outlier removal');
+  });
+
+  test("should report genuine inconsistency when below target with POOR CV and POOR MAD", () => {
+    // GIVEN per-operation runs are genuinely inconsistent across all runs, with throughput below target
+    const givenStats = buildThroughputStats({relativeMarginOfError: 5, coefficientOfVariation: 0.5, mad: 2, median: 5});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 50, 100);
+
+    // THEN it reports genuinely inconsistent
+    expect(actualResult).toContain('genuinely inconsistent');
+    expect(actualResult).toContain('environment stability');
+  });
+
+  test("should report genuine inconsistency when below target with POOR CV and null MAD", () => {
+    // GIVEN per-operation variance is high with unknown dispersion pattern, and throughput below target
+    const givenStats = buildThroughputStats({relativeMarginOfError: 5, coefficientOfVariation: 0.5, mad: null});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 50, 100);
+
+    // THEN it reports genuinely inconsistent
+    expect(actualResult).toContain('genuinely inconsistent');
+  });
+
+  test("should report code is too slow when below target with GOOD RME and GOOD CV", () => {
+    // GIVEN per-operation stats are precise and consistent, but throughput is below target
+    const givenStats = buildThroughputStats({relativeMarginOfError: 5, coefficientOfVariation: 0.05});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 50, 100);
+
+    // THEN it reports code is too slow
+    expect(actualResult).toContain('consistently');
+    expect(actualResult).toContain('below target');
+    expect(actualResult).toContain('too slow');
+  });
+
+  test("should handle null RME when mean is near zero", () => {
+    // GIVEN per-operation timing mean is near zero making relative metrics unavailable
+    const givenStats = buildThroughputStats({relativeMarginOfError: null, coefficientOfVariation: null});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 200, 100);
+
+    // THEN it reports near-zero mean
+    expect(actualResult).toContain('near zero');
+  });
+
+  test("should handle null CI when insufficient data", () => {
+    // GIVEN per-operation timing has insufficient data for confidence intervals
+    const givenStats = buildThroughputStats({confidenceInterval: null});
+
+    // WHEN interpreting throughput results
+    const actualResult = generateThroughputInterpretation(givenStats, 200, 100);
+
+    // THEN it reports insufficient data
+    expect(actualResult).toContain('insufficient data');
+  });
+
+  test("should include error info note when errors present", () => {
+    // GIVEN per-operation stats are precise and consistent, with some operations excluded due to errors
+    const givenStats = buildThroughputStats({relativeMarginOfError: 5, coefficientOfVariation: 0.05});
+    const givenErrorInfo = {errorCount: 3, totalIterations: 100, allowedRate: 0.1};
+
+    // WHEN interpreting throughput results with error info
+    const actualResult = generateThroughputInterpretation(givenStats, 200, 100, givenErrorInfo);
+
+    // THEN it includes the error exclusion note
+    expect(actualResult).toContain('3 of 100 operations failed');
+    expect(actualResult).toContain('stats reflect successful ops only');
+  });
+
+  test("should report above target at exact boundary (100%)", () => {
+    // GIVEN per-operation stats are precise and consistent, with throughput exactly at target
+    const givenStats = buildThroughputStats({relativeMarginOfError: 5, coefficientOfVariation: 0.05});
+
+    // WHEN interpreting throughput at the exact target boundary
+    const actualResult = generateThroughputInterpretation(givenStats, 100, 100);
+
+    // THEN it reports target met (since actualOps >= expectedOps)
+    expect(actualResult).toContain('throughput target met');
   });
 });

--- a/test/matchers-throughput.test.ts
+++ b/test/matchers-throughput.test.ts
@@ -1,0 +1,1043 @@
+import '../src/main';
+import {processThroughputResults} from '../src/helpers';
+import {mockThroughputTimings} from './test-utils';
+import {printExpected, printReceived} from "jest-matcher-utils";
+
+describe("toAchieveOpsPerSecond", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("pass", () => {
+    test("should pass the assertion when function achieves target ops/sec", () => {
+      // GIVEN a function that completes 5 operations within a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting it achieves at least 5 ops/sec
+      // THEN the assertion passes
+      expect(() => undefined).toAchieveOpsPerSecond(5, {duration: givenDuration});
+    });
+
+    test("should pass the assertion when warmup iterations are configured", () => {
+      // GIVEN a function that completes 5 operations within a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting with 2 warmup iterations before measurement
+      // THEN the assertion passes
+      expect(() => undefined).toAchieveOpsPerSecond(5, {duration: givenDuration, warmup: 2});
+    });
+
+    test("should pass the assertion when outlier removal is enabled", () => {
+      // GIVEN a function where 9 operations are fast and 1 is an extreme outlier
+      const givenOpDurations = [1, 1, 1, 1, 1, 1, 1, 1, 1, 500];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting with outlier removal enabled
+      // THEN the assertion passes based on total operations completed
+      expect(() => undefined).toAchieveOpsPerSecond(10, {duration: givenDuration, outliers: 'remove'});
+    });
+
+    test("should default warmup to 0 when not specified", () => {
+      // GIVEN a function that completes 5 operations within a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      const givenCallback = jest.fn();
+
+      // WHEN asserting without specifying warmup
+      expect(givenCallback).toAchieveOpsPerSecond(5, {duration: givenDuration});
+
+      // THEN the callback is called exactly once per operation with no extra warmup calls
+      expect(givenCallback).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe("fail", () => {
+    test("should fail the assertion when function does not achieve target ops/sec", () => {
+      // GIVEN a function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const givenExpectedOps = 10;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting a target of 10 ops/sec
+      // THEN the assertion fails because the function is too slow
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(givenExpectedOps, {duration: givenDuration});
+      }).toThrow(`expected function to achieve at least ${printExpected(givenExpectedOps)} ops/sec`);
+    });
+
+    test("should include diagnostic stats in failure message", () => {
+      // GIVEN a function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN the throughput assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toAchieveOpsPerSecond(10000, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the failure message includes throughput summary and per-operation diagnostics
+      expect(actualMessage).toContain('Throughput:');
+      expect(actualMessage).toContain('ops/sec');
+      expect(actualMessage).toContain('Per-operation timing');
+      expect(actualMessage).toContain('Interpretation:');
+    });
+  });
+
+  describe(".not", () => {
+    test("should pass with .not when function does not achieve target ops/sec", () => {
+      // GIVEN a function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting .not with a target well above actual throughput
+      // THEN the negated assertion passes
+      expect(() => undefined).not.toAchieveOpsPerSecond(10000, {duration: givenDuration});
+    });
+
+    test("should fail with .not when function exceeds target ops/sec", () => {
+      // GIVEN a function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const givenTarget = 1;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting .not with a target below actual throughput
+      // THEN the negated assertion fails
+      expect(() => {
+        expect(() => undefined).not.toAchieveOpsPerSecond(givenTarget, {duration: givenDuration});
+      }).toThrow(`expected function NOT to achieve at least ${printExpected(givenTarget)} ops/sec`);
+    });
+  });
+
+  describe("diagnostics", () => {
+    test("should show throughput summary in failure message", () => {
+      // GIVEN a function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN the throughput assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toAchieveOpsPerSecond(10000, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the failure message includes a throughput summary line
+      expect(actualMessage).toContain('Throughput: 5 ops/sec over 1000ms (5 total operations)');
+    });
+
+    test("should show throughput CI in failure message", () => {
+      // GIVEN a function that achieves approximately 5 ops/sec with slight per-op variance
+      const givenOpDurations = [10, 10.1, 9.9, 10.2, 9.8];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN the throughput assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toAchieveOpsPerSecond(10000, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the failure message includes a throughput confidence interval
+      expect(actualMessage).toMatch(/CI 95%: \[\d+, \d+\] ops\/sec/);
+    });
+
+    test("should show target shortfall info when below target", () => {
+      // GIVEN a function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN the throughput assertion fails against a 10 ops/sec target
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toAchieveOpsPerSecond(10, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the message includes shortfall info
+      expect(actualMessage).toContain('Target: 10 ops/sec');
+      expect(actualMessage).toContain('shortfall of');
+    });
+
+    test("should show target surplus info when above target via .not", () => {
+      // GIVEN a function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN the negated assertion fails because actual exceeds target
+      let actualMessage = '';
+      try {
+        expect(() => undefined).not.toAchieveOpsPerSecond(1, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the message includes surplus info
+      expect(actualMessage).toContain('surplus of');
+    });
+
+    test("should show per-operation timing stats in failure message", () => {
+      // GIVEN a function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN the throughput assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toAchieveOpsPerSecond(10000, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the failure message includes per-operation timing statistics
+      expect(actualMessage).toContain('Per-operation timing (n=5');
+      expect(actualMessage).toContain('mean=');
+      expect(actualMessage).toContain('median=');
+      expect(actualMessage).toContain('stddev=');
+      expect(actualMessage).toContain('MAD=');
+      expect(actualMessage).toContain('Distribution:');
+      expect(actualMessage).toContain('Shape:');
+    });
+
+    test("should show setup/teardown active hint when hooks are provided", () => {
+      // GIVEN a function that achieves 5 ops/sec with a setup hook configured
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN the throughput assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toAchieveOpsPerSecond(10000, {
+          duration: givenDuration,
+          setup: () => undefined,
+        });
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the message includes setup/teardown active hint
+      expect(actualMessage).toContain('setup/teardown active');
+    });
+
+    test("should NOT show setup/teardown hint when no hooks provided", () => {
+      // GIVEN a function that achieves 5 ops/sec without any hooks
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN the throughput assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toAchieveOpsPerSecond(10000, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the message does NOT include setup/teardown active hint
+      expect(actualMessage).not.toContain('setup/teardown active');
+    });
+
+    test("should show error rate line in diagnostics when errors occur within tolerance", () => {
+      // GIVEN a function where 1 out of 5 operations fails within error tolerance
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const givenErrorIndices = new Set([2]);
+      mockThroughputTimings(givenOpDurations, givenDuration, givenErrorIndices);
+      let callCount = 0;
+
+      // WHEN the throughput assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => {
+          callCount++;
+          if (callCount === 3) throw new Error("foo-error");
+        }).toAchieveOpsPerSecond(10000, {duration: givenDuration, allowedErrorRate: 0.5});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the error rate line appears in the diagnostic output
+      expect(actualMessage).toContain('Error rate: 1/5 (20.0%) [within 50.0% tolerance]');
+    });
+
+    test("should show CI unavailable and warnings for n=1", () => {
+      // GIVEN a function that completes only 1 operation within the time window
+      const givenOpDurations = [10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN the throughput assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toAchieveOpsPerSecond(10000, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the failure message indicates insufficient data for confidence intervals
+      expect(actualMessage).toContain('N/A (insufficient data)');
+      expect(actualMessage).toContain('Warnings:');
+    });
+  });
+
+  describe("setup/teardown lifecycle", () => {
+    test("should call suite setup once and pass state to callback", () => {
+      // GIVEN a function that runs 3 operations with suite-level setup returning shared state
+      const givenOpDurations = [10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      const givenSetupData = ["foo-item-1", "foo-item-2"];
+      const actualCallbackArgs: unknown[] = [];
+
+      // WHEN the throughput assertion runs
+      expect((data: unknown) => {
+        actualCallbackArgs.push(data);
+      }).toAchieveOpsPerSecond(1, {
+        duration: givenDuration,
+        setup: () => givenSetupData,
+      });
+
+      // THEN the callback receives the setup state on every invocation
+      expect(actualCallbackArgs).toEqual([givenSetupData, givenSetupData, givenSetupData]);
+    });
+
+    test("should call suite teardown once after loop completes", () => {
+      // GIVEN a function that runs 3 operations with suite-level setup and teardown
+      const givenOpDurations = [10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      const givenTeardownArgs: unknown[] = [];
+      const givenSetupData = "foo-state";
+
+      // WHEN the throughput assertion runs
+      expect(() => undefined).toAchieveOpsPerSecond(1, {
+        duration: givenDuration,
+        setup: () => givenSetupData,
+        teardown: (state) => {
+          givenTeardownArgs.push(state);
+        },
+      });
+
+      // THEN teardown is called exactly once with the setup state
+      expect(givenTeardownArgs).toEqual([givenSetupData]);
+    });
+
+    test("should call teardown even when callback throws and allowedErrorRate is 0", () => {
+      // GIVEN a function that always throws during measurement
+      const givenOpDurations = [10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      let actualTeardownCalled = false;
+
+      // WHEN the callback throws during throughput measurement
+      try {
+        expect(() => {
+          throw new Error("foo-error");
+        }).toAchieveOpsPerSecond(1, {
+          duration: givenDuration,
+          teardown: () => {
+            actualTeardownCalled = true;
+          },
+        });
+      } catch {
+        // expected
+      }
+
+      // THEN teardown is still called
+      expect(actualTeardownCalled).toBe(true);
+    });
+
+    test("should call setupEach before each operation and teardownEach after", () => {
+      // GIVEN a function that runs 3 operations with per-operation setup and teardown hooks
+      const givenOpDurations = [10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      const actualOrder: string[] = [];
+
+      // WHEN the throughput assertion runs
+      expect(() => {
+        actualOrder.push('callback');
+      }).toAchieveOpsPerSecond(1, {
+        duration: givenDuration,
+        setupEach: () => {
+          actualOrder.push('setupEach');
+        },
+        teardownEach: () => {
+          actualOrder.push('teardownEach');
+        },
+      });
+
+      // THEN each operation is wrapped in setupEach → callback → teardownEach order
+      const expectedOrder = [
+        'setupEach', 'callback', 'teardownEach',
+        'setupEach', 'callback', 'teardownEach',
+        'setupEach', 'callback', 'teardownEach',
+      ];
+      expect(actualOrder).toEqual(expectedOrder);
+    });
+
+    test("should pass setupEach return value as second arg to callback and teardownEach", () => {
+      // GIVEN a function that runs 2 operations with suite and per-operation setup providing state
+      const givenOpDurations = [10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      const givenSuiteState = "foo-suite";
+      let callCount = 0;
+      const actualCallbackArgs: unknown[][] = [];
+      const actualTeardownArgs: unknown[][] = [];
+
+      // WHEN the throughput assertion runs
+      expect((...args: unknown[]) => {
+        actualCallbackArgs.push([...args]);
+      }).toAchieveOpsPerSecond(1, {
+        duration: givenDuration,
+        setup: () => givenSuiteState,
+        setupEach: (suiteState) => `foo-iter-${++callCount}`,
+        teardownEach: (suiteState, iterState) => {
+          actualTeardownArgs.push([suiteState, iterState]);
+        },
+      });
+
+      // THEN the callback and teardownEach receive both suite and iteration state
+      expect(actualCallbackArgs).toEqual([
+        [givenSuiteState, "foo-iter-1"],
+        [givenSuiteState, "foo-iter-2"],
+      ]);
+      expect(actualTeardownArgs).toEqual([
+        [givenSuiteState, "foo-iter-1"],
+        [givenSuiteState, "foo-iter-2"],
+      ]);
+    });
+
+    test("should call setupEach/teardownEach during warmup", () => {
+      // GIVEN a function that runs 2 measured operations with 2 warmup iterations and per-operation hooks
+      const givenOpDurations = [10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      let actualSetupEachCount = 0;
+      let actualTeardownEachCount = 0;
+
+      // WHEN the throughput assertion runs
+      expect(() => undefined).toAchieveOpsPerSecond(1, {
+        duration: givenDuration,
+        warmup: 2,
+        setupEach: () => {
+          actualSetupEachCount++;
+        },
+        teardownEach: () => {
+          actualTeardownEachCount++;
+        },
+      });
+
+      // THEN per-operation hooks are called during both warmup and measurement phases
+      const expectedTotalCalls = 2 + 2; // 2 warmup + 2 measured
+      expect(actualSetupEachCount).toBe(expectedTotalCalls);
+      expect(actualTeardownEachCount).toBe(expectedTotalCalls);
+    });
+  });
+
+  describe("error rate", () => {
+    test("should propagate error immediately when allowedErrorRate is 0", () => {
+      // GIVEN a function that always throws during measurement
+      const givenOpDurations = [10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting throughput without error tolerance (default 0)
+      // THEN the error propagates immediately
+      expect(() => {
+        expect(() => {
+          throw new Error("foo-error");
+        }).toAchieveOpsPerSecond(1, {duration: givenDuration});
+      }).toThrow("foo-error");
+    });
+
+    test("should fail when error rate exceeds allowed tolerance", () => {
+      // GIVEN a function where 3 out of 5 operations fail with only 10% error tolerance
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const givenErrorIndices = new Set([0, 1, 2]);
+      mockThroughputTimings(givenOpDurations, givenDuration, givenErrorIndices);
+      let callCount = 0;
+
+      // WHEN the throughput assertion runs
+      expect(() => {
+        expect(() => {
+          if (callCount < 3) { callCount++; throw new Error("foo-error"); }
+          callCount++;
+        }).toAchieveOpsPerSecond(1, {duration: givenDuration, allowedErrorRate: 0.1});
+      }).toThrow('exceeds allowed');
+    });
+
+    test("should fail with all-failed message when all operations error", () => {
+      // GIVEN a function where all 3 operations fail with error tolerance enabled
+      const givenOpDurations = [10, 10, 10];
+      const givenDuration = 1000;
+      const givenErrorIndices = new Set([0, 1, 2]);
+      mockThroughputTimings(givenOpDurations, givenDuration, givenErrorIndices);
+
+      // WHEN all operations fail during throughput measurement
+      expect(() => {
+        expect(() => {
+          throw new Error("foo-error");
+        }).toAchieveOpsPerSecond(1, {duration: givenDuration, allowedErrorRate: 1});
+      }).toThrow('100% error rate');
+    });
+
+    test("should tolerate errors within allowed rate and report correct ops/sec", () => {
+      // GIVEN a function where 1 out of 5 operations fails with 50% error tolerance
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const givenErrorIndices = new Set([2]);
+      mockThroughputTimings(givenOpDurations, givenDuration, givenErrorIndices);
+      let callCount = 0;
+
+      // WHEN 1 out of 5 operations fails within tolerance
+      // THEN the assertion passes with the correct throughput from successful operations
+      expect(() => {
+        callCount++;
+        if (callCount === 3) throw new Error("foo-error");
+      }).toAchieveOpsPerSecond(4, {duration: givenDuration, allowedErrorRate: 0.5});
+    });
+
+    test("should pass when error rate equals allowed rate exactly", () => {
+      // GIVEN a function where 1 out of 10 operations fails with exactly 10% error tolerance
+      const givenOpDurations = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const givenErrorIndices = new Set([4]);
+      mockThroughputTimings(givenOpDurations, givenDuration, givenErrorIndices);
+      let callCount = 0;
+
+      // WHEN the error rate equals the allowed rate exactly
+      // THEN the assertion passes because the check is strict greater-than
+      expect(() => {
+        callCount++;
+        if (callCount === 5) throw new Error("foo-error");
+      }).toAchieveOpsPerSecond(1, {duration: givenDuration, allowedErrorRate: 0.1});
+    });
+  });
+
+  describe("outlier removal", () => {
+    test("should keep outliers by default", () => {
+      // GIVEN a function where 9 operations are fast and 1 is an extreme outlier
+      const givenOpDurations = [1, 1, 1, 1, 1, 1, 1, 1, 1, 500];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting throughput without outlier removal (default)
+      // THEN the assertion fails because the outlier inflates the mean per-op time
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(50, {duration: givenDuration});
+      }).toThrow('ops/sec');
+    });
+
+    test("should remove outliers when enabled", () => {
+      // GIVEN a function where 9 operations are fast and 1 is an extreme outlier
+      const givenOpDurations = [1, 1, 1, 1, 1, 1, 1, 1, 1, 500];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting with outlier removal enabled
+      // THEN the assertion passes because throughput counts actual completed operations
+      expect(() => undefined).toAchieveOpsPerSecond(10, {duration: givenDuration, outliers: 'remove'});
+    });
+  });
+
+  describe("edge cases", () => {
+    test("should handle n=1 when only one operation fits in duration", () => {
+      // GIVEN a function that completes only 1 operation within the time window
+      const givenOpDurations = [10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting with a target of 1 ops/sec
+      // THEN the assertion passes
+      expect(() => undefined).toAchieveOpsPerSecond(1, {duration: givenDuration});
+    });
+  });
+
+  describe("input validation", () => {
+    test("should throw validation error when received value is not a function", () => {
+      expect(() => {
+        expect(42).toAchieveOpsPerSecond(100, {duration: 1000});
+      }).toThrow("jest-performance-matchers: expected value must be a function, received number");
+    });
+
+    test("should throw validation error when expectedOpsPerSecond is negative", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(-1, {duration: 1000});
+      }).toThrow("jest-performance-matchers: expected ops/sec must be a positive number, received -1");
+    });
+
+    test("should throw validation error when expectedOpsPerSecond is zero", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(0, {duration: 1000});
+      }).toThrow("jest-performance-matchers: expected ops/sec must be a positive number, received 0");
+    });
+
+    test("should throw validation error when expectedOpsPerSecond is NaN", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(NaN, {duration: 1000});
+      }).toThrow("jest-performance-matchers: expected ops/sec must be a positive number, received NaN");
+    });
+
+    test("should throw validation error when expectedOpsPerSecond is Infinity", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(Infinity, {duration: 1000});
+      }).toThrow("jest-performance-matchers: expected ops/sec must be a positive number, received Infinity");
+    });
+
+    test("should throw validation error when duration is negative", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: -1});
+      }).toThrow("jest-performance-matchers: duration must be a positive number, received -1");
+    });
+
+    test("should throw validation error when duration is zero", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 0});
+      }).toThrow("jest-performance-matchers: duration must be a positive number, received 0");
+    });
+
+    test("should throw validation error when duration is NaN", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: NaN});
+      }).toThrow("jest-performance-matchers: duration must be a positive number, received NaN");
+    });
+
+    test("should throw validation error when duration is Infinity", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: Infinity});
+      }).toThrow("jest-performance-matchers: duration must be a positive number, received Infinity");
+    });
+
+    test("should throw validation error when options is null", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing null for testing
+        expect(() => undefined).toAchieveOpsPerSecond(100, null);
+      }).toThrow("jest-performance-matchers: options must be an object with duration");
+    });
+
+    test("should throw validation error when warmup is negative", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 1000, warmup: -1});
+      }).toThrow("jest-performance-matchers: warmup must be a non-negative integer, received -1");
+    });
+
+    test("should throw validation error when warmup is non-integer", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 1000, warmup: 1.5});
+      }).toThrow("jest-performance-matchers: warmup must be a non-negative integer, received 1.5");
+    });
+
+    test("should throw validation error when outliers is invalid string", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing invalid outliers for testing
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 1000, outliers: 'invalid'});
+      }).toThrow("jest-performance-matchers: outliers must be 'remove' or 'keep', received 'invalid'");
+    });
+
+    test("should throw validation error when allowedErrorRate exceeds 1", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 1000, allowedErrorRate: 1.5});
+      }).toThrow("jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received 1.5");
+    });
+
+    test("should throw validation error when allowedErrorRate is negative", () => {
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 1000, allowedErrorRate: -0.1});
+      }).toThrow("jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received -0.1");
+    });
+
+    test("should throw validation error when setup is not a function", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing invalid setup for testing
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 1000, setup: 42});
+      }).toThrow("jest-performance-matchers: setup must be a function if provided, received number");
+    });
+
+    test("should throw validation error when teardown is not a function", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing invalid teardown for testing
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 1000, teardown: 42});
+      }).toThrow("jest-performance-matchers: teardown must be a function if provided, received number");
+    });
+
+    test("should throw validation error when setupEach is not a function", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing invalid setupEach for testing
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 1000, setupEach: 42});
+      }).toThrow("jest-performance-matchers: setupEach must be a function if provided, received number");
+    });
+
+    test("should throw validation error when teardownEach is not a function", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing invalid teardownEach for testing
+        expect(() => undefined).toAchieveOpsPerSecond(100, {duration: 1000, teardownEach: 42});
+      }).toThrow("jest-performance-matchers: teardownEach must be a function if provided, received number");
+    });
+  });
+});
+
+describe("toResolveAtOpsPerSecond", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("pass", () => {
+    test("should pass the assertion when async function achieves target ops/sec", async () => {
+      // GIVEN an async function that completes 5 operations within a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting it achieves at least 5 ops/sec
+      // THEN the assertion passes
+      await expect(async () => undefined).toResolveAtOpsPerSecond(5, {duration: givenDuration});
+    });
+
+    test("should pass the assertion when warmup is configured", async () => {
+      // GIVEN an async function that completes 5 operations within a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting with 2 warmup iterations
+      // THEN the assertion passes
+      await expect(async () => undefined).toResolveAtOpsPerSecond(5, {duration: givenDuration, warmup: 2});
+    });
+  });
+
+  describe("fail", () => {
+    test("should fail the assertion when async function does not achieve target ops/sec", async () => {
+      // GIVEN an async function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const givenExpectedOps = 10;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting a target of 10 ops/sec
+      // THEN the assertion fails
+      let actualMessage = '';
+      try {
+        await expect(async () => undefined).toResolveAtOpsPerSecond(givenExpectedOps, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+      expect(actualMessage).toContain(`expected function to achieve at least ${printExpected(givenExpectedOps)} ops/sec`);
+    });
+  });
+
+  describe(".not", () => {
+    test("should pass with .not when async function does not achieve target ops/sec", async () => {
+      // GIVEN an async function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting .not with a target well above actual throughput
+      // THEN the negated assertion passes
+      await expect(async () => undefined).not.toResolveAtOpsPerSecond(10000, {duration: givenDuration});
+    });
+
+    test("should fail with .not when async function exceeds target ops/sec", async () => {
+      // GIVEN an async function that achieves 5 ops/sec over a 1-second window
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const givenTarget = 1;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting .not with a target below actual throughput
+      // THEN the negated assertion fails
+      let actualMessage = '';
+      try {
+        await expect(async () => undefined).not.toResolveAtOpsPerSecond(givenTarget, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+      expect(actualMessage).toContain(`expected function NOT to achieve at least ${printExpected(givenTarget)} ops/sec`);
+    });
+  });
+
+  describe("async setup/teardown", () => {
+    test("should call async setup once and pass state to callback", async () => {
+      // GIVEN an async function that runs 3 operations with async suite-level setup
+      const givenOpDurations = [10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      const givenSetupData = "foo-async-state";
+      const actualCallbackArgs: unknown[] = [];
+
+      // WHEN the throughput assertion runs
+      await expect(async (data: unknown) => {
+        actualCallbackArgs.push(data);
+      }).toResolveAtOpsPerSecond(1, {
+        duration: givenDuration,
+        setup: async () => givenSetupData,
+      });
+
+      // THEN the callback receives the setup state on every invocation
+      expect(actualCallbackArgs).toEqual([givenSetupData, givenSetupData, givenSetupData]);
+    });
+
+    test("should call async teardown even when callback rejects", async () => {
+      // GIVEN an async function that always rejects during measurement
+      const givenOpDurations = [10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      let actualTeardownCalled = false;
+
+      // WHEN the callback rejects during throughput measurement
+      try {
+        await expect(async () => {
+          throw new Error("foo-async-error");
+        }).toResolveAtOpsPerSecond(1, {
+          duration: givenDuration,
+          teardown: async () => {
+            actualTeardownCalled = true;
+          },
+        });
+      } catch {
+        // expected
+      }
+
+      // THEN teardown is still called
+      expect(actualTeardownCalled).toBe(true);
+    });
+
+    test("should call async setupEach per operation", async () => {
+      // GIVEN an async function that runs 3 operations with async per-operation setup
+      const givenOpDurations = [10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      let actualSetupEachCount = 0;
+
+      // WHEN the throughput assertion runs
+      await expect(async () => undefined).toResolveAtOpsPerSecond(1, {
+        duration: givenDuration,
+        setupEach: async () => {
+          actualSetupEachCount++;
+        },
+      });
+
+      // THEN async setupEach is called once per operation
+      expect(actualSetupEachCount).toBe(3);
+    });
+
+    test("should call async teardownEach per operation", async () => {
+      // GIVEN an async function that runs 3 operations with async per-operation teardown
+      const givenOpDurations = [10, 10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      let actualTeardownEachCount = 0;
+
+      // WHEN the throughput assertion runs
+      await expect(async () => undefined).toResolveAtOpsPerSecond(1, {
+        duration: givenDuration,
+        teardownEach: async () => {
+          actualTeardownEachCount++;
+        },
+      });
+
+      // THEN async teardownEach is called once per operation
+      expect(actualTeardownEachCount).toBe(3);
+    });
+  });
+
+  describe("error rate (async)", () => {
+    test("should propagate rejection immediately when allowedErrorRate is 0", async () => {
+      // GIVEN an async function that always rejects during measurement
+      const givenOpDurations = [10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting throughput without error tolerance
+      // THEN the rejection propagates immediately
+      let actualError: Error | undefined;
+      try {
+        await expect(async () => {
+          throw new Error("foo-async-error");
+        }).toResolveAtOpsPerSecond(1, {duration: givenDuration});
+      } catch (e) {
+        actualError = e as Error;
+      }
+      expect(actualError?.message).toBe("foo-async-error");
+    });
+
+    test("should fail with all-failed message when all async operations error", async () => {
+      // GIVEN an async function where all 3 operations fail with error tolerance enabled
+      const givenOpDurations = [10, 10, 10];
+      const givenDuration = 1000;
+      const givenErrorIndices = new Set([0, 1, 2]);
+      mockThroughputTimings(givenOpDurations, givenDuration, givenErrorIndices);
+
+      // WHEN all operations fail during throughput measurement
+      let actualMessage = '';
+      try {
+        await expect(async () => {
+          throw new Error("foo-error");
+        }).toResolveAtOpsPerSecond(1, {duration: givenDuration, allowedErrorRate: 1});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the all-failed message is shown
+      expect(actualMessage).toContain('100% error rate');
+    });
+
+    test("should fail when async error rate exceeds tolerance", async () => {
+      // GIVEN an async function where 3 out of 5 operations fail with only 10% error tolerance
+      const givenOpDurations = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const givenErrorIndices = new Set([0, 1, 2]);
+      mockThroughputTimings(givenOpDurations, givenDuration, givenErrorIndices);
+      let callCount = 0;
+
+      // WHEN the error rate exceeds the allowed tolerance
+      let actualMessage = '';
+      try {
+        await expect(async () => {
+          if (callCount < 3) { callCount++; throw new Error("foo-error"); }
+          callCount++;
+        }).toResolveAtOpsPerSecond(1, {duration: givenDuration, allowedErrorRate: 0.1});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+      expect(actualMessage).toContain('exceeds allowed');
+    });
+  });
+
+  describe("async warmup", () => {
+    test("should run async warmup with setupEach and teardownEach", async () => {
+      // GIVEN an async function that runs 2 measured operations with 2 warmup iterations and async hooks
+      const givenOpDurations = [10, 10];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+      let actualSetupEachCount = 0;
+      let actualTeardownEachCount = 0;
+
+      // WHEN the throughput assertion runs with warmup
+      await expect(async () => undefined).toResolveAtOpsPerSecond(1, {
+        duration: givenDuration,
+        warmup: 2,
+        setupEach: async () => {
+          actualSetupEachCount++;
+        },
+        teardownEach: async () => {
+          actualTeardownEachCount++;
+        },
+      });
+
+      // THEN async per-operation hooks are called during both warmup and measurement phases
+      const expectedTotalCalls = 2 + 2; // 2 warmup + 2 measured
+      expect(actualSetupEachCount).toBe(expectedTotalCalls);
+      expect(actualTeardownEachCount).toBe(expectedTotalCalls);
+    });
+  });
+
+  describe("outlier removal (async)", () => {
+    test("should remove outliers when enabled for async matchers", async () => {
+      // GIVEN an async function where 9 operations are fast and 1 is an extreme outlier
+      const givenOpDurations = [1, 1, 1, 1, 1, 1, 1, 1, 1, 500];
+      const givenDuration = 1000;
+      mockThroughputTimings(givenOpDurations, givenDuration);
+
+      // WHEN asserting with outlier removal enabled
+      // THEN the assertion passes because throughput counts actual completed operations
+      await expect(async () => undefined).toResolveAtOpsPerSecond(10, {duration: givenDuration, outliers: 'remove'});
+    });
+  });
+
+  describe("input validation (async)", () => {
+    test("should throw validation error when received value is not a function", async () => {
+      let actualMessage = '';
+      try {
+        await expect(42).toResolveAtOpsPerSecond(100, {duration: 1000});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+      expect(actualMessage).toContain("jest-performance-matchers: expected value must be a function, received number");
+    });
+
+    test("should throw validation error when expectedOpsPerSecond is negative", async () => {
+      let actualMessage = '';
+      try {
+        await expect(async () => undefined).toResolveAtOpsPerSecond(-1, {duration: 1000});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+      expect(actualMessage).toContain("jest-performance-matchers: expected ops/sec must be a positive number, received -1");
+    });
+
+    test("should throw validation error when duration is zero", async () => {
+      let actualMessage = '';
+      try {
+        await expect(async () => undefined).toResolveAtOpsPerSecond(100, {duration: 0});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+      expect(actualMessage).toContain("jest-performance-matchers: duration must be a positive number, received 0");
+    });
+  });
+});
+
+describe("processThroughputResults", () => {
+  test("should return pass=false when all operations failed", () => {
+    // GIVEN all operations failed during measurement
+    const actualResult = processThroughputResults({
+      durations: [], totalOps: 5, errorCount: 5, allowedErrorRate: 1,
+      expectedOpsPerSecond: 100, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false,
+    });
+
+    // THEN the result fails with an all-failed error message
+    expect(actualResult.pass).toBe(false);
+    expect(actualResult.message()).toContain('100% error rate');
+  });
+
+  test("should return pass=false when error rate exceeds tolerance", () => {
+    // GIVEN 3 out of 5 operations failed exceeding the 10% tolerance
+    const actualResult = processThroughputResults({
+      durations: [10, 10], totalOps: 5, errorCount: 3, allowedErrorRate: 0.1,
+      expectedOpsPerSecond: 1, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false,
+    });
+
+    // THEN the result fails with an error rate exceeded message
+    expect(actualResult.pass).toBe(false);
+    expect(actualResult.message()).toContain('exceeds allowed');
+  });
+
+  test("should return pass=true for a single successful operation", () => {
+    // GIVEN a single operation completed successfully
+    const actualResult = processThroughputResults({
+      durations: [10], totalOps: 1, errorCount: 0, allowedErrorRate: 0,
+      expectedOpsPerSecond: 1, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false,
+    });
+
+    // THEN the result passes
+    expect(actualResult.pass).toBe(true);
+  });
+});

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -22,3 +22,57 @@ export function mockFunctionProcessTimesInterleaved(durationsA: number[], durati
   }
   mockFunctionProcessTimes(interleaved);
 }
+
+function msToHrtime(ms: number): [number, number] {
+  const seconds = Math.floor(ms / 1000);
+  const nanos = Math.round((ms - seconds * 1000) * 1e6);
+  return [seconds, nanos];
+}
+
+/**
+ * Mock hrtime for throughput matchers that use a time-bounded while loop.
+ *
+ * Call pattern for successful ops: loop-check + t0 + t1 = 3 calls each
+ * Call pattern for erroring ops: loop-check + t0 = 2 calls each (t1 is never reached)
+ * Total: 1 (deadline) + 3*(N-E) + 2*E + 1 (exit check) = 3N - E + 2
+ *
+ * @param opDurations - array of per-operation durations in ms
+ * @param durationWindow - the duration option passed to the matcher (ms)
+ * @param errorIndices - optional set of 0-based operation indices that will throw (skips t1 call)
+ */
+export function mockThroughputTimings(opDurations: number[], durationWindow: number, errorIndices?: Set<number>): void {
+  const hrtimeValues: [number, number][] = [];
+  const baseMs = 1000; // arbitrary base time
+
+  // Call 1: initial timestamp for deadline calculation (deadline = base + durationWindow)
+  hrtimeValues.push(msToHrtime(baseMs));
+
+  let currentMs = baseMs;
+  for (let i = 0; i < opDurations.length; i++) {
+    // Loop condition check: current time must be < deadline
+    hrtimeValues.push(msToHrtime(currentMs));
+    // t0: start timing
+    hrtimeValues.push(msToHrtime(currentMs));
+
+    if (errorIndices && errorIndices.has(i)) {
+      // Error case: callback throws before t1, so no t1 call
+      // Advance time by the op duration for realism
+      currentMs += opDurations[i];
+    } else {
+      // Success case: t1 = end timing (current + opDuration)
+      currentMs += opDurations[i];
+      hrtimeValues.push(msToHrtime(currentMs));
+    }
+  }
+
+  // Final loop condition check: past deadline to exit
+  hrtimeValues.push(msToHrtime(baseMs + durationWindow + 1));
+
+  let callIndex = 0;
+  jest.spyOn(process, "hrtime").mockImplementation(() => {
+    if (callIndex >= hrtimeValues.length) {
+      return msToHrtime(baseMs + durationWindow + 1000);
+    }
+    return hrtimeValues[callIndex++];
+  });
+}


### PR DESCRIPTION
## Summary

- Add `toAchieveOpsPerSecond` (sync) and `toResolveAtOpsPerSecond` (async) throughput matchers that run a function for a specified duration, count completed operations, and assert ops/sec >= target
- Add `generateThroughputInterpretation` with RME/CV/MAD diagnostic matrix for actionable failure messages
- Add throughput CI derived from per-op timing CI via bound inversion
- Full options support: `duration`, `warmup`, `outliers`, `setup`/`teardown`/`setupEach`/`teardownEach`, `allowedErrorRate`
- Add comments and separate setup from test logic across all example files

## Test plan

- [x] All 586 tests pass with 100% statement and branch coverage
- [x] `npm run lint` passes with zero errors
- [x] `npm run build` compiles cleanly
- [x] SonarCloud: 0 bugs, 0 vulnerabilities, 0 code smells
- [x] Zero production dependencies

Closes #14