### PR TITLE
fix: simplify redundant unknown | Promise<unknown> union types

### DIFF
--- a/src/matchers-comparative.ts
+++ b/src/matchers-comparative.ts
@@ -146,9 +146,9 @@ export async function toResolveFasterThan(promiseA: AsyncCallback, promiseB: Asy
   warmup?: number,
   confidence?: number,
   outliers?: 'remove' | 'keep',
-  setup?: () => unknown | Promise<unknown>,
+  setup?: () => unknown,
   teardown?: (suiteState: unknown) => void | Promise<void>,
-  setupEach?: (suiteState: unknown) => unknown | Promise<unknown>,
+  setupEach?: (suiteState: unknown) => unknown,
   teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>,
   allowedErrorRate?: number,
 }) {

--- a/src/matchers-quantile.ts
+++ b/src/matchers-quantile.ts
@@ -79,9 +79,9 @@ export async function toResolveWithinQuantile(promise: (...args: any[]) => Promi
   quantile: number,
   warmup?: number,
   outliers?: 'remove' | 'keep',
-  setup?: () => unknown | Promise<unknown>,
+  setup?: () => unknown,
   teardown?: (suiteState: unknown) => void | Promise<void>,
-  setupEach?: (suiteState: unknown) => unknown | Promise<unknown>,
+  setupEach?: (suiteState: unknown) => unknown,
   teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>,
   allowedErrorRate?: number,
 }) {

--- a/src/matchers-single.ts
+++ b/src/matchers-single.ts
@@ -39,7 +39,7 @@ export function toCompleteWithin(callback: (state: any) => unknown, expectedDura
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
 export async function toResolveWithin(promise: (state: any) => Promise<unknown>, expectedDurationInMilliseconds: number, options?: {
-  setup?: () => unknown | Promise<unknown>,
+  setup?: () => unknown,
   teardown?: (state: unknown) => void | Promise<void>,
 }) {
   validateCallback(promise);


### PR DESCRIPTION
## Summary

- Replace `unknown | Promise<unknown>` with `unknown` in async hook return types across 3 matcher files
- `unknown` already subsumes `Promise<unknown>`, making the union redundant (SonarCloud rule S6571)
- Affected files: `matchers-single.ts`, `matchers-quantile.ts`, `matchers-comparative.ts`

## Test plan

- [x] All 586 tests pass with 100% coverage
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] No behavioral changes

Closes #82