### PR TITLE
refactor: reduce cognitive complexity in formatThroughputStatsBlock and quantile matchers

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -345,33 +345,28 @@ interface ThroughputStatsBlockOptions {
   errorInfo?: ErrorInfo;
 }
 
-function formatThroughputStatsBlock(opts: ThroughputStatsBlockOptions): string {
-  const {stats, durations, actualOpsPerSecond, expectedOpsPerSecond, duration, totalOps, setupTeardownActive, errorInfo} = opts;
-
-  // Throughput CI: invert per-op timing CI bounds (inversion flips upper/lower)
-  let throughputCIText: string;
-  if (stats.confidenceInterval === null) {
-    throughputCIText = '  CI 95%: N/A (insufficient data)';
-  } else {
-    const [ciLower, ciUpper] = stats.confidenceInterval;
-    if (ciLower <= 0) {
-      throughputCIText = '  CI 95%: N/A (per-op CI lower bound is non-positive)';
-    } else {
-      const throughputLower = 1000 / ciUpper;
-      const throughputUpper = 1000 / ciLower;
-      throughputCIText = `  CI 95%: [${Math.round(throughputLower)}, ${Math.round(throughputUpper)}] ops/sec`;
-    }
+function formatThroughputCI(confidenceInterval: [number, number] | null): string {
+  if (confidenceInterval === null) {
+    return '  CI 95%: N/A (insufficient data)';
   }
+  const [ciLower, ciUpper] = confidenceInterval;
+  if (ciLower <= 0) {
+    return '  CI 95%: N/A (per-op CI lower bound is non-positive)';
+  }
+  const throughputLower = 1000 / ciUpper;
+  const throughputUpper = 1000 / ciLower;
+  return `  CI 95%: [${Math.round(throughputLower)}, ${Math.round(throughputUpper)}] ops/sec`;
+}
 
-  // Target comparison
+function formatTargetComparison(actualOpsPerSecond: number, expectedOpsPerSecond: number): string {
   const diff = actualOpsPerSecond - expectedOpsPerSecond;
   const absDiff = Math.abs(diff);
   const pctDiff = (absDiff / expectedOpsPerSecond) * 100;
-  const targetText = diff >= 0
-    ? `  Target: ${Math.round(expectedOpsPerSecond)} ops/sec — surplus of ${Math.round(absDiff)} ops/sec (${pctDiff.toFixed(1)}%)`
-    : `  Target: ${Math.round(expectedOpsPerSecond)} ops/sec — shortfall of ${Math.round(absDiff)} ops/sec (${pctDiff.toFixed(1)}%)`;
+  const label = diff >= 0 ? 'surplus' : 'shortfall';
+  return `  Target: ${Math.round(expectedOpsPerSecond)} ops/sec — ${label} of ${Math.round(absDiff)} ops/sec (${pctDiff.toFixed(1)}%)`;
+}
 
-  // Per-op timing section (reuse classification primitives)
+function formatPerOpTimingSection(stats: Stats, durations: number[], setupTeardownActive: boolean): string[] {
   const rmeTag = classifyRME(stats.relativeMarginOfError);
   const cvTag = classifyCV(stats.coefficientOfVariation);
   const madTag = classifyMAD(stats.mad, stats.median);
@@ -403,17 +398,25 @@ function formatThroughputStatsBlock(opts: ThroughputStatsBlockOptions): string {
     madText = `${stats.mad.toFixed(2)}ms${madTagSuffix}`;
   }
 
-  const interpretation = generateThroughputInterpretation(stats, actualOpsPerSecond, expectedOpsPerSecond, errorInfo);
-
-  const lines = [
-    `Throughput: ${Math.round(actualOpsPerSecond)} ops/sec over ${Math.round(duration)}ms (${totalOps} total operations)`,
-    throughputCIText,
-    targetText,
-    '',
+  return [
     `Per-operation timing (n=${stats.n}${setupTeardownActive ? ', setup/teardown active' : ''}): mean=${formatStatValue(stats.mean)}ms, median=${formatStatValue(stats.median)}ms, stddev=${formatStatValue(stats.stddev)}ms, MAD=${madText}`,
     `  CI 95%: ${ciText} | RME: ${rmeText} | CV: ${cvText}`,
     `  Distribution: min=${formatStatValue(stats.min)}ms | P25=${formatStatValue(p25)}ms | P50=${formatStatValue(p50)}ms | P75=${formatStatValue(p75)}ms | P90=${formatStatValue(p90)}ms | max=${formatStatValue(stats.max)}ms`,
     `  Shape: ${shapeDiag.label} (skewness=${skewnessText}) | ${shapeDiag.sparkline}`,
+  ];
+}
+
+function formatThroughputStatsBlock(opts: ThroughputStatsBlockOptions): string {
+  const {stats, durations, actualOpsPerSecond, expectedOpsPerSecond, duration, totalOps, setupTeardownActive, errorInfo} = opts;
+
+  const interpretation = generateThroughputInterpretation(stats, actualOpsPerSecond, expectedOpsPerSecond, errorInfo);
+
+  const lines = [
+    `Throughput: ${Math.round(actualOpsPerSecond)} ops/sec over ${Math.round(duration)}ms (${totalOps} total operations)`,
+    formatThroughputCI(stats.confidenceInterval),
+    formatTargetComparison(actualOpsPerSecond, expectedOpsPerSecond),
+    '',
+    ...formatPerOpTimingSection(stats, durations, setupTeardownActive),
     '',
     `Interpretation: ${interpretation}`,
   ];

--- a/src/matchers-quantile.ts
+++ b/src/matchers-quantile.ts
@@ -2,6 +2,44 @@ import {nowInMillis} from "./timing";
 import {validateCallback, validateDuration, validateQuantileOptions} from "./validators";
 import {processQuantileResults} from "./helpers";
 
+interface QuantileHooks {
+  setup?: () => unknown;
+  teardown?: (suiteState: unknown) => void;
+  setupEach?: (suiteState: unknown) => unknown;
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+type SyncCallback = (...args: any[]) => unknown;
+
+function warmupSync(callback: SyncCallback, warmupCount: number, suiteState: unknown, hooks: QuantileHooks): void {
+  for (let i = 0; i < warmupCount; i++) {
+    const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
+    try {
+      callback(suiteState, iterState);
+    } finally {
+      if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
+    }
+  }
+}
+
+function measureSync(callback: SyncCallback, suiteState: unknown, durations: number[], hooks: QuantileHooks, allowedErrorRate: number): number {
+  let errorCount = 0;
+  const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
+  try {
+    const t0 = nowInMillis();
+    callback(suiteState, iterState);
+    const t1 = nowInMillis();
+    durations.push(t1 - t0);
+  } catch (e) {
+    if (allowedErrorRate === 0) throw e;
+    errorCount = 1;
+  } finally {
+    if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
+  }
+  return errorCount;
+}
+
 /**
  * Assert that the synchronous code executed for (I) times, runs (Q)% the time within the given duration
  * @param callback The callback to execute and measure
@@ -26,45 +64,62 @@ export function toCompleteWithinQuantile(callback: (...args: any[]) => unknown, 
 
   const count = options.iterations;
   const quantile = options.quantile;
-  const warmup = options.warmup ?? 0;
-  const {setup, teardown, setupEach, teardownEach} = options;
-
-  const suiteState = setup ? setup() : undefined;
-
+  const hooks: QuantileHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const suiteState = hooks.setup ? hooks.setup() : undefined;
 
   try {
-    for (let i = 0; i < warmup; i++) {
-      const iterState = setupEach ? setupEach(suiteState) : undefined;
-      try {
-        callback(suiteState, iterState);
-      } finally {
-        if (teardownEach) teardownEach(suiteState, iterState);
-      }
-    }
+    warmupSync(callback, options.warmup ?? 0, suiteState, hooks);
 
     const durations: number[] = [];
     let errorCount = 0;
     for (let i = 0; i < count; i++) {
-      const iterState = setupEach ? setupEach(suiteState) : undefined;
-      try {
-        const t0 = nowInMillis();
-        callback(suiteState, iterState);
-        const t1 = nowInMillis();
-        durations.push(t1 - t0);
-      } catch (e) {
-        if (allowedErrorRate === 0) throw e;
-        errorCount++;
-      } finally {
-        if (teardownEach) teardownEach(suiteState, iterState);
-      }
+      errorCount += measureSync(callback, suiteState, durations, hooks, allowedErrorRate);
     }
 
-    const setupTeardownActive = !!(setup || teardown || setupEach || teardownEach);
+    const setupTeardownActive = !!(hooks.setup || hooks.teardown || hooks.setupEach || hooks.teardownEach);
     return processQuantileResults({durations, count, quantile, errorCount, allowedErrorRate, expectedDurationInMilliseconds, setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove'});
   } finally {
-    if (teardown) teardown(suiteState);
+    if (hooks.teardown) hooks.teardown(suiteState);
   }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+type AsyncCallback = (...args: any[]) => Promise<unknown>;
+
+interface AsyncQuantileHooks {
+  setup?: () => unknown;
+  teardown?: (suiteState: unknown) => void | Promise<void>;
+  setupEach?: (suiteState: unknown) => unknown;
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>;
+}
+
+async function warmupAsync(callback: AsyncCallback, warmupCount: number, suiteState: unknown, hooks: AsyncQuantileHooks): Promise<void> {
+  for (let i = 0; i < warmupCount; i++) {
+    const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
+    try {
+      await callback(suiteState, iterState);
+    } finally {
+      if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
+    }
+  }
+}
+
+async function measureAsync(callback: AsyncCallback, suiteState: unknown, durations: number[], hooks: AsyncQuantileHooks, allowedErrorRate: number): Promise<number> {
+  let errorCount = 0;
+  const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
+  try {
+    const t0 = nowInMillis();
+    await callback(suiteState, iterState);
+    const t1 = nowInMillis();
+    durations.push(t1 - t0);
+  } catch (e) {
+    if (allowedErrorRate === 0) throw e;
+    errorCount = 1;
+  } finally {
+    if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
+  }
+  return errorCount;
 }
 
 /**
@@ -91,42 +146,22 @@ export async function toResolveWithinQuantile(promise: (...args: any[]) => Promi
 
   const count = options.iterations;
   const quantile = options.quantile;
-  const warmup = options.warmup ?? 0;
-  const {setup, teardown, setupEach, teardownEach} = options;
-
-  const suiteState = setup ? await setup() : undefined;
+  const hooks: AsyncQuantileHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const suiteState = hooks.setup ? await hooks.setup() : undefined;
 
   try {
-    for (let i = 0; i < warmup; i++) {
-      const iterState = setupEach ? await setupEach(suiteState) : undefined;
-      try {
-        await promise(suiteState, iterState);
-      } finally {
-        if (teardownEach) await teardownEach(suiteState, iterState);
-      }
-    }
+    await warmupAsync(promise, options.warmup ?? 0, suiteState, hooks);
 
     const durations: number[] = [];
     let errorCount = 0;
     for (let i = 0; i < count; i++) {
-      const iterState = setupEach ? await setupEach(suiteState) : undefined;
-      try {
-        const t0 = nowInMillis();
-        await promise(suiteState, iterState);
-        const t1 = nowInMillis();
-        durations.push(t1 - t0);
-      } catch (e) {
-        if (allowedErrorRate === 0) throw e;
-        errorCount++;
-      } finally {
-        if (teardownEach) await teardownEach(suiteState, iterState);
-      }
+      errorCount += await measureAsync(promise, suiteState, durations, hooks, allowedErrorRate);
     }
 
-    const setupTeardownActive = !!(setup || teardown || setupEach || teardownEach);
+    const setupTeardownActive = !!(hooks.setup || hooks.teardown || hooks.setupEach || hooks.teardownEach);
     return processQuantileResults({durations, count, quantile, errorCount, allowedErrorRate, expectedDurationInMilliseconds, setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove'});
   } finally {
-    if (teardown) await teardown(suiteState);
+    if (hooks.teardown) await hooks.teardown(suiteState);
   }
 }


### PR DESCRIPTION
## Summary

- **Extract helpers from `formatThroughputStatsBlock`** (`src/helpers.ts`): Split into `formatThroughputCI`, `formatTargetComparison`, and `formatPerOpTimingSection` to reduce cognitive complexity from 20 to well below 15
- **Extract helpers from `toCompleteWithinQuantile` and `toResolveWithinQuantile`** (`src/matchers-quantile.ts`): Extract `warmupSync`/`measureSync` and `warmupAsync`/`measureAsync` helpers, following the same pattern used in `matchers-comparative.ts` and `matchers-throughput.ts`, reducing complexity from 17 to below 15
- No behavioral changes — all 586 existing tests pass unchanged with 100% coverage

Closes #81

## Test plan

- [x] All 586 existing tests pass unchanged
- [x] 100% statement and branch coverage maintained
- [x] `npm run lint` — zero errors
- [x] `npm run build` — compiles cleanly
- [x] SonarCloud analysis reports 0 issues on both changed files