### PR TITLE
refactor: consolidate duplicate hooks interfaces into shared types

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,86 @@
+/** Shared lifecycle hooks and execution helpers for sync and async matchers. */
+
+import {nowInMillis} from "./timing";
+
+export interface SyncHooks {
+  setup?: () => unknown;
+  teardown?: (suiteState: unknown) => void;
+  setupEach?: (suiteState: unknown) => unknown;
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void;
+}
+
+export interface AsyncHooks {
+  setup?: () => unknown;
+  teardown?: (suiteState: unknown) => void | Promise<void>;
+  setupEach?: (suiteState: unknown) => unknown;
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+export type SyncCallback = (...args: any[]) => unknown;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
+export type AsyncCallback = (...args: any[]) => Promise<unknown>;
+
+export function runSyncWithHooks(callback: SyncCallback, suiteState: unknown, hooks: SyncHooks): void {
+  const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
+  try {
+    callback(suiteState, iterState);
+  } finally {
+    if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
+  }
+}
+
+export async function runAsyncWithHooks(callback: AsyncCallback, suiteState: unknown, hooks: AsyncHooks): Promise<void> {
+  const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
+  try {
+    await callback(suiteState, iterState);
+  } finally {
+    if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
+  }
+}
+
+export function measureSync(callback: SyncCallback, suiteState: unknown, durations: number[], hooks: SyncHooks, allowedErrorRate: number): number {
+  let errorCount = 0;
+  const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
+  try {
+    const t0 = nowInMillis();
+    callback(suiteState, iterState);
+    const t1 = nowInMillis();
+    durations.push(t1 - t0);
+  } catch (e) {
+    if (allowedErrorRate === 0) throw e;
+    errorCount = 1;
+  } finally {
+    if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
+  }
+  return errorCount;
+}
+
+export async function measureAsync(callback: AsyncCallback, suiteState: unknown, durations: number[], hooks: AsyncHooks, allowedErrorRate: number): Promise<number> {
+  let errorCount = 0;
+  const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
+  try {
+    const t0 = nowInMillis();
+    await callback(suiteState, iterState);
+    const t1 = nowInMillis();
+    durations.push(t1 - t0);
+  } catch (e) {
+    if (allowedErrorRate === 0) throw e;
+    errorCount = 1;
+  } finally {
+    if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
+  }
+  return errorCount;
+}
+
+export function warmupSync(callback: SyncCallback, warmupCount: number, suiteState: unknown, hooks: SyncHooks): void {
+  for (let i = 0; i < warmupCount; i++) {
+    runSyncWithHooks(callback, suiteState, hooks);
+  }
+}
+
+export async function warmupAsync(callback: AsyncCallback, warmupCount: number, suiteState: unknown, hooks: AsyncHooks): Promise<void> {
+  for (let i = 0; i < warmupCount; i++) {
+    await runAsyncWithHooks(callback, suiteState, hooks);
+  }
+}

--- a/src/matchers-comparative.ts
+++ b/src/matchers-comparative.ts
@@ -1,48 +1,12 @@
-import {nowInMillis} from "./timing";
 import {validateCallback, validateComparativeOptions} from "./validators";
 import {processComparativeResults} from "./helpers";
+import {SyncHooks, AsyncHooks, SyncCallback, AsyncCallback, runSyncWithHooks, runAsyncWithHooks, measureSync, measureAsync} from "./hooks";
 
-interface ComparativeHooks {
-  setup?: () => unknown;
-  teardown?: (suiteState: unknown) => void;
-  setupEach?: (suiteState: unknown) => unknown;
-  teardownEach?: (suiteState: unknown, iterState: unknown) => void;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
-type SyncCallback = (...args: any[]) => unknown;
-
-function warmupSync(callbackA: SyncCallback, callbackB: SyncCallback, warmupCount: number, suiteState: unknown, hooks: ComparativeHooks): void {
+function warmupSync(callbackA: SyncCallback, callbackB: SyncCallback, warmupCount: number, suiteState: unknown, hooks: SyncHooks): void {
   for (let i = 0; i < warmupCount; i++) {
     runSyncWithHooks(callbackA, suiteState, hooks);
     runSyncWithHooks(callbackB, suiteState, hooks);
   }
-}
-
-function runSyncWithHooks(callback: SyncCallback, suiteState: unknown, hooks: ComparativeHooks): void {
-  const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
-  try {
-    callback(suiteState, iterState);
-  } finally {
-    if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
-  }
-}
-
-function measureSync(callback: SyncCallback, suiteState: unknown, durations: number[], hooks: ComparativeHooks, allowedErrorRate: number): number {
-  let errorCount = 0;
-  const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
-  try {
-    const t0 = nowInMillis();
-    callback(suiteState, iterState);
-    const t1 = nowInMillis();
-    durations.push(t1 - t0);
-  } catch (e) {
-    if (allowedErrorRate === 0) throw e;
-    errorCount = 1;
-  } finally {
-    if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
-  }
-  return errorCount;
 }
 
 /**
@@ -66,7 +30,7 @@ export function toBeFasterThan(callbackA: SyncCallback, callbackB: SyncCallback,
 
   const count = options.iterations;
   const confidence = options.confidence ?? 0.95;
-  const hooks: ComparativeHooks = options;
+  const hooks: SyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
   const suiteState = hooks.setup ? hooks.setup() : undefined;
 
@@ -94,47 +58,11 @@ export function toBeFasterThan(callbackA: SyncCallback, callbackB: SyncCallback,
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
-type AsyncCallback = (...args: any[]) => Promise<unknown>;
-
-interface AsyncComparativeHooks {
-  setup?: () => unknown;
-  teardown?: (suiteState: unknown) => void | Promise<void>;
-  setupEach?: (suiteState: unknown) => unknown;
-  teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>;
-}
-
-async function warmupAsync(callbackA: AsyncCallback, callbackB: AsyncCallback, warmupCount: number, suiteState: unknown, hooks: AsyncComparativeHooks): Promise<void> {
+async function warmupAsync(callbackA: AsyncCallback, callbackB: AsyncCallback, warmupCount: number, suiteState: unknown, hooks: AsyncHooks): Promise<void> {
   for (let i = 0; i < warmupCount; i++) {
     await runAsyncWithHooks(callbackA, suiteState, hooks);
     await runAsyncWithHooks(callbackB, suiteState, hooks);
   }
-}
-
-async function runAsyncWithHooks(callback: AsyncCallback, suiteState: unknown, hooks: AsyncComparativeHooks): Promise<void> {
-  const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
-  try {
-    await callback(suiteState, iterState);
-  } finally {
-    if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
-  }
-}
-
-async function measureAsync(callback: AsyncCallback, suiteState: unknown, durations: number[], hooks: AsyncComparativeHooks, allowedErrorRate: number): Promise<number> {
-  let errorCount = 0;
-  const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
-  try {
-    const t0 = nowInMillis();
-    await callback(suiteState, iterState);
-    const t1 = nowInMillis();
-    durations.push(t1 - t0);
-  } catch (e) {
-    if (allowedErrorRate === 0) throw e;
-    errorCount = 1;
-  } finally {
-    if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
-  }
-  return errorCount;
 }
 
 /**
@@ -158,7 +86,7 @@ export async function toResolveFasterThan(promiseA: AsyncCallback, promiseB: Asy
 
   const count = options.iterations;
   const confidence = options.confidence ?? 0.95;
-  const hooks: AsyncComparativeHooks = options;
+  const hooks: AsyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
   const suiteState = hooks.setup ? await hooks.setup() : undefined;
 

--- a/src/matchers-quantile.ts
+++ b/src/matchers-quantile.ts
@@ -1,44 +1,6 @@
-import {nowInMillis} from "./timing";
 import {validateCallback, validateDuration, validateQuantileOptions} from "./validators";
 import {processQuantileResults} from "./helpers";
-
-interface QuantileHooks {
-  setup?: () => unknown;
-  teardown?: (suiteState: unknown) => void;
-  setupEach?: (suiteState: unknown) => unknown;
-  teardownEach?: (suiteState: unknown, iterState: unknown) => void;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
-type SyncCallback = (...args: any[]) => unknown;
-
-function warmupSync(callback: SyncCallback, warmupCount: number, suiteState: unknown, hooks: QuantileHooks): void {
-  for (let i = 0; i < warmupCount; i++) {
-    const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
-    try {
-      callback(suiteState, iterState);
-    } finally {
-      if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
-    }
-  }
-}
-
-function measureSync(callback: SyncCallback, suiteState: unknown, durations: number[], hooks: QuantileHooks, allowedErrorRate: number): number {
-  let errorCount = 0;
-  const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
-  try {
-    const t0 = nowInMillis();
-    callback(suiteState, iterState);
-    const t1 = nowInMillis();
-    durations.push(t1 - t0);
-  } catch (e) {
-    if (allowedErrorRate === 0) throw e;
-    errorCount = 1;
-  } finally {
-    if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
-  }
-  return errorCount;
-}
+import {SyncHooks, AsyncHooks, SyncCallback, AsyncCallback, measureSync, measureAsync, warmupSync, warmupAsync} from "./hooks";
 
 /**
  * Assert that the synchronous code executed for (I) times, runs (Q)% the time within the given duration
@@ -46,8 +8,7 @@ function measureSync(callback: SyncCallback, suiteState: unknown, durations: num
  * @param expectedDurationInMilliseconds The expected duration in milliseconds
  * @param options Iteration count, quantile threshold, and optional setup/teardown hooks
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
-export function toCompleteWithinQuantile(callback: (...args: any[]) => unknown, expectedDurationInMilliseconds: number, options: {
+export function toCompleteWithinQuantile(callback: SyncCallback, expectedDurationInMilliseconds: number, options: {
   iterations: number,
   quantile: number,
   warmup?: number,
@@ -64,7 +25,7 @@ export function toCompleteWithinQuantile(callback: (...args: any[]) => unknown, 
 
   const count = options.iterations;
   const quantile = options.quantile;
-  const hooks: QuantileHooks = options;
+  const hooks: SyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
   const suiteState = hooks.setup ? hooks.setup() : undefined;
 
@@ -84,52 +45,13 @@ export function toCompleteWithinQuantile(callback: (...args: any[]) => unknown, 
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
-type AsyncCallback = (...args: any[]) => Promise<unknown>;
-
-interface AsyncQuantileHooks {
-  setup?: () => unknown;
-  teardown?: (suiteState: unknown) => void | Promise<void>;
-  setupEach?: (suiteState: unknown) => unknown;
-  teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>;
-}
-
-async function warmupAsync(callback: AsyncCallback, warmupCount: number, suiteState: unknown, hooks: AsyncQuantileHooks): Promise<void> {
-  for (let i = 0; i < warmupCount; i++) {
-    const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
-    try {
-      await callback(suiteState, iterState);
-    } finally {
-      if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
-    }
-  }
-}
-
-async function measureAsync(callback: AsyncCallback, suiteState: unknown, durations: number[], hooks: AsyncQuantileHooks, allowedErrorRate: number): Promise<number> {
-  let errorCount = 0;
-  const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
-  try {
-    const t0 = nowInMillis();
-    await callback(suiteState, iterState);
-    const t1 = nowInMillis();
-    durations.push(t1 - t0);
-  } catch (e) {
-    if (allowedErrorRate === 0) throw e;
-    errorCount = 1;
-  } finally {
-    if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
-  }
-  return errorCount;
-}
-
 /**
  * Assert that the asynchronous code executed for (I) times, resolves (Q)% the time within the given duration
  * @param promise The promise to execute and measure
  * @param expectedDurationInMilliseconds The expected duration in milliseconds
  * @param options Iteration count, quantile threshold, and optional setup/teardown hooks
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
-export async function toResolveWithinQuantile(promise: (...args: any[]) => Promise<unknown>, expectedDurationInMilliseconds: number, options: {
+export async function toResolveWithinQuantile(promise: AsyncCallback, expectedDurationInMilliseconds: number, options: {
   iterations: number,
   quantile: number,
   warmup?: number,
@@ -146,7 +68,7 @@ export async function toResolveWithinQuantile(promise: (...args: any[]) => Promi
 
   const count = options.iterations;
   const quantile = options.quantile;
-  const hooks: AsyncQuantileHooks = options;
+  const hooks: AsyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
   const suiteState = hooks.setup ? await hooks.setup() : undefined;
 

--- a/src/matchers-throughput.ts
+++ b/src/matchers-throughput.ts
@@ -1,31 +1,11 @@
 import {nowInMillis} from "./timing";
 import {validateCallback, validateExpectedOpsPerSecond, validateThroughputOptions} from "./validators";
 import {processThroughputResults} from "./helpers";
-
-interface ThroughputHooks {
-  setup?: () => unknown;
-  teardown?: (suiteState: unknown) => void;
-  setupEach?: (suiteState: unknown) => unknown;
-  teardownEach?: (suiteState: unknown, iterState: unknown) => void;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
-type SyncCallback = (...args: any[]) => unknown;
-
-function warmupSync(callback: SyncCallback, warmupCount: number, suiteState: unknown, hooks: ThroughputHooks): void {
-  for (let i = 0; i < warmupCount; i++) {
-    const iterState = hooks.setupEach ? hooks.setupEach(suiteState) : undefined;
-    try {
-      callback(suiteState, iterState);
-    } finally {
-      if (hooks.teardownEach) hooks.teardownEach(suiteState, iterState);
-    }
-  }
-}
+import {SyncHooks, AsyncHooks, SyncCallback, AsyncCallback, warmupSync, warmupAsync} from "./hooks";
 
 function measureSyncThroughput(
   callback: SyncCallback, duration: number, suiteState: unknown,
-  hooks: ThroughputHooks, allowedErrorRate: number,
+  hooks: SyncHooks, allowedErrorRate: number,
 ): { durations: number[]; errorCount: number } {
   const durations: number[] = [];
   let errorCount = 0;
@@ -67,7 +47,7 @@ export function toAchieveOpsPerSecond(callback: SyncCallback, expectedOpsPerSeco
   validateExpectedOpsPerSecond(expectedOpsPerSecond);
   validateThroughputOptions(options);
 
-  const hooks: ThroughputHooks = options;
+  const hooks: SyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
   const suiteState = hooks.setup ? hooks.setup() : undefined;
 
@@ -88,30 +68,9 @@ export function toAchieveOpsPerSecond(callback: SyncCallback, expectedOpsPerSeco
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- expect.extend erases generics at runtime
-type AsyncCallback = (...args: any[]) => Promise<unknown>;
-
-interface AsyncThroughputHooks {
-  setup?: () => unknown;
-  teardown?: (suiteState: unknown) => void | Promise<void>;
-  setupEach?: (suiteState: unknown) => unknown;
-  teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>;
-}
-
-async function warmupAsync(callback: AsyncCallback, warmupCount: number, suiteState: unknown, hooks: AsyncThroughputHooks): Promise<void> {
-  for (let i = 0; i < warmupCount; i++) {
-    const iterState = hooks.setupEach ? await hooks.setupEach(suiteState) : undefined;
-    try {
-      await callback(suiteState, iterState);
-    } finally {
-      if (hooks.teardownEach) await hooks.teardownEach(suiteState, iterState);
-    }
-  }
-}
-
 async function measureAsyncThroughput(
   callback: AsyncCallback, duration: number, suiteState: unknown,
-  hooks: AsyncThroughputHooks, allowedErrorRate: number,
+  hooks: AsyncHooks, allowedErrorRate: number,
 ): Promise<{ durations: number[]; errorCount: number }> {
   const durations: number[] = [];
   let errorCount = 0;
@@ -153,7 +112,7 @@ export async function toResolveAtOpsPerSecond(callback: AsyncCallback, expectedO
   validateExpectedOpsPerSecond(expectedOpsPerSecond);
   validateThroughputOptions(options);
 
-  const hooks: AsyncThroughputHooks = options;
+  const hooks: AsyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
   const suiteState = hooks.setup ? await hooks.setup() : undefined;
 


### PR DESCRIPTION
## Summary

- Extract 6 identical hook interfaces (`ComparativeHooks`, `AsyncComparativeHooks`, `ThroughputHooks`, `AsyncThroughputHooks`, `QuantileHooks`, `AsyncQuantileHooks`) into shared `SyncHooks` and `AsyncHooks` interfaces in `src/hooks.ts`
- Remove duplicate interface definitions from `matchers-comparative.ts`, `matchers-throughput.ts`, and `matchers-quantile.ts`
- No behavioral changes — all existing tests pass unchanged

Closes #85

## Test plan

- [x] All 586 existing tests pass
- [x] 100% statement and branch coverage maintained
- [x] ESLint: zero errors
- [x] TypeScript build compiles cleanly
- [x] SonarCloud: 0 bugs, 0 vulnerabilities, 0 code smells