### PR TITLE
feat: add configurable diagnostic log levels (closes #72)

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -310,6 +310,36 @@ export function generateThroughputInterpretation(
   return message;
 }
 
+/**
+ * Check whether any warning condition is present that warrants diagnostic output on a passing test.
+ *
+ * Conditions checked:
+ * 1. Sample adequacy is POOR (n < 10) — also covers "errors reduced effective n below threshold"
+ *    since `stats.n` reflects successful iterations only after error exclusion
+ * 2. RME is POOR (> 30%)
+ * 3. CV is POOR (> 0.3) — also covers "outliers inflating variance" since POOR CV always triggers
+ *    regardless of MAD; the MAD-based hint about outliers appears in the interpretation text
+ * 4. CI upper bound exceeds the user's threshold (budget overrun risk)
+ * 5. Non-zero error rate — some iterations were excluded
+ */
+export function hasWarningConditions(
+  stats: Stats,
+  expectedDuration?: number,
+  errorInfo?: { errorCount: number; totalIterations: number; allowedRate: number },
+): boolean {
+  if (classifySampleAdequacy(stats.n).label === 'POOR') return true;
+
+  const rme = classifyRME(stats.relativeMarginOfError);
+  if (rme !== null && rme.label === 'POOR') return true;
+
+  const cv = classifyCV(stats.coefficientOfVariation);
+  if (cv !== null && cv.label === 'POOR') return true;
+
+  if (expectedDuration !== undefined && stats.confidenceInterval !== null && stats.confidenceInterval[1] > expectedDuration) return true;
+
+  return errorInfo !== undefined && errorInfo.errorCount > 0;
+}
+
 function interpretThroughputAbove(rme: Tag, cv: Tag, mad: Tag | null, pctOfTarget: number): string {
   const surplus = pctOfTarget > 100 ? ` (${(pctOfTarget - 100).toFixed(1)}% above target)` : '';
   if (cv.label === 'POOR') {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,6 +9,7 @@ import {
   generateInterpretation,
   generateComparisonInterpretation,
   generateThroughputInterpretation,
+  hasWarningConditions,
   formatTag,
   formatPValue,
 } from "./diagnostics";
@@ -19,6 +20,22 @@ export interface ErrorInfo {
   errorCount: number;
   totalIterations: number;
   allowedRate: number;
+}
+
+export type LogDiagnostics = 'INFO' | 'WARN' | 'FAIL';
+
+const LOG_PREFIX = '[jest-performance-matchers]';
+
+export function logDiagnosticsIfNeeded(pass: boolean, statsBlock: string, logLevel: LogDiagnostics, warnings: boolean): void {
+  if (!pass) return;
+  if (logLevel === 'FAIL') return;
+  if (logLevel === 'INFO') {
+    console.info(`${LOG_PREFIX} Diagnostics:\n${statsBlock}`);
+    return;
+  }
+  if (warnings) {
+    console.warn(`${LOG_PREFIX} Diagnostics (warnings detected):\n${statsBlock}`);
+  }
 }
 
 export function formatStatValue(value: number | null): string {
@@ -89,6 +106,7 @@ export interface QuantileResultsOptions {
   errorCount: number; allowedErrorRate: number;
   expectedDurationInMilliseconds: number;
   setupTeardownActive: boolean; removeOutliersEnabled: boolean;
+  logDiagnostics: LogDiagnostics;
 }
 
 export function processQuantileResults(opts: QuantileResultsOptions): { message: () => string; pass: boolean } {
@@ -121,14 +139,17 @@ export function processQuantileResults(opts: QuantileResultsOptions): { message:
     totalIterations: count,
     allowedRate: allowedErrorRate
   } : undefined;
-  return assertDurationQuantile(count, quantile, quantileValue, effectiveDurations, expectedDurationInMilliseconds, setupTeardownActive, errorInfo);
+  return assertDurationQuantile(count, quantile, quantileValue, effectiveDurations, expectedDurationInMilliseconds, setupTeardownActive, errorInfo, opts.logDiagnostics);
 }
 
-export function assertDurationQuantile(iterations: number, quantile: number, quantileValue: number, durations: number[], expectedDurationInMilliseconds: number, setupTeardownActive?: boolean, errorInfo?: ErrorInfo) {
+export function assertDurationQuantile(iterations: number, quantile: number, quantileValue: number, durations: number[], expectedDurationInMilliseconds: number, setupTeardownActive: boolean | undefined, errorInfo: ErrorInfo | undefined, logDiagnostics: LogDiagnostics) {
   const stats = calcStats(durations);
   const statsBlock = formatStatsBlock(stats, durations, expectedDurationInMilliseconds, setupTeardownActive, errorInfo);
+  const pass = quantileValue <= expectedDurationInMilliseconds;
 
-  if (quantileValue <= expectedDurationInMilliseconds) {
+  logDiagnosticsIfNeeded(pass, statsBlock, logDiagnostics, hasWarningConditions(stats, expectedDurationInMilliseconds, errorInfo));
+
+  if (pass) {
     return {
       message: () =>
         `expected that ${quantile}% of the time when running ${iterations} iterations,\nthe function duration to be greater than ${printExpected(expectedDurationInMilliseconds)} (ms),\ninstead it was ${printReceived(quantileValue)} (ms)\n\n${statsBlock}`,
@@ -211,6 +232,7 @@ export interface ComparativeResultsOptions {
   errorCountA: number; errorCountB: number;
   allowedErrorRate: number; confidence: number;
   setupTeardownActive: boolean; removeOutliersEnabled: boolean;
+  logDiagnostics: LogDiagnostics;
 }
 
 export function processComparativeResults(opts: ComparativeResultsOptions): { message: () => string; pass: boolean } {
@@ -264,6 +286,9 @@ export function processComparativeResults(opts: ComparativeResultsOptions): { me
 
   const statsBlock = formatComparativeStatsBlock({statsA, statsB, durationsA: effectiveA, durationsB: effectiveB, tTest, confidence, setupTeardownActive, errorInfoA, errorInfoB});
 
+  const warnings = hasWarningConditions(statsA, undefined, errorInfoA) || hasWarningConditions(statsB, undefined, errorInfoB);
+  logDiagnosticsIfNeeded(pass, statsBlock, opts.logDiagnostics, warnings);
+
   if (pass) {
     return {
       pass: true,
@@ -285,6 +310,7 @@ export interface ThroughputResultsOptions {
   duration: number;
   setupTeardownActive: boolean;
   removeOutliersEnabled: boolean;
+  logDiagnostics: LogDiagnostics;
 }
 
 export function processThroughputResults(opts: ThroughputResultsOptions): { message: () => string; pass: boolean } {
@@ -323,6 +349,8 @@ export function processThroughputResults(opts: ThroughputResultsOptions): { mess
 
   const errorInfo: ErrorInfo | undefined = errorCount > 0 ? {errorCount, totalIterations: totalOps, allowedRate: allowedErrorRate} : undefined;
   const statsBlock = formatThroughputStatsBlock({stats, durations: effectiveDurations, actualOpsPerSecond, expectedOpsPerSecond, duration, totalOps: durations.length, setupTeardownActive, errorInfo});
+
+  logDiagnosticsIfNeeded(pass, statsBlock, opts.logDiagnostics, hasWarningConditions(stats, undefined, errorInfo));
 
   if (pass) {
     return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ declare global {
         setupEach?: (suiteState: T) => U,
         teardownEach?: (suiteState: T, iterState: U) => void,
         allowedErrorRate?: number,
+        logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
       }): R;
 
       toResolveWithin<T = void>(expectedDurationInMilliseconds: number, options?: {
@@ -50,6 +51,7 @@ declare global {
         setupEach?: (suiteState: T) => U | Promise<U>,
         teardownEach?: (suiteState: T, iterState: U) => void | Promise<void>,
         allowedErrorRate?: number,
+        logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
       }): Promise<R>;
 
       toBeFasterThan<T = void, U = void>(comparisonFn: (...args: unknown[]) => unknown, options: {
@@ -62,6 +64,7 @@ declare global {
         setupEach?: (suiteState: T) => U,
         teardownEach?: (suiteState: T, iterState: U) => void,
         allowedErrorRate?: number,
+        logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
       }): R;
 
       toResolveFasterThan<T = void, U = void>(comparisonFn: (...args: unknown[]) => Promise<unknown>, options: {
@@ -74,6 +77,7 @@ declare global {
         setupEach?: (suiteState: T) => U | Promise<U>,
         teardownEach?: (suiteState: T, iterState: U) => void | Promise<void>,
         allowedErrorRate?: number,
+        logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
       }): Promise<R>;
 
       toAchieveOpsPerSecond<T = void, U = void>(expectedOpsPerSecond: number, options: {
@@ -85,6 +89,7 @@ declare global {
         setupEach?: (suiteState: T) => U,
         teardownEach?: (suiteState: T, iterState: U) => void,
         allowedErrorRate?: number,
+        logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
       }): R;
 
       toResolveAtOpsPerSecond<T = void, U = void>(expectedOpsPerSecond: number, options: {
@@ -96,6 +101,7 @@ declare global {
         setupEach?: (suiteState: T) => U | Promise<U>,
         teardownEach?: (suiteState: T, iterState: U) => void | Promise<void>,
         allowedErrorRate?: number,
+        logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
       }): Promise<R>;
     }
   }

--- a/src/matchers-comparative.ts
+++ b/src/matchers-comparative.ts
@@ -23,6 +23,7 @@ export function toBeFasterThan(callbackA: SyncCallback, callbackB: SyncCallback,
   setupEach?: (suiteState: unknown) => unknown,
   teardownEach?: (suiteState: unknown, iterState: unknown) => void,
   allowedErrorRate?: number,
+  logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
 }) {
   validateCallback(callbackA);
   validateCallback(callbackB);
@@ -32,6 +33,7 @@ export function toBeFasterThan(callbackA: SyncCallback, callbackB: SyncCallback,
   const confidence = options.confidence ?? 0.95;
   const hooks: SyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const logDiagnostics = options.logDiagnostics ?? 'WARN';
   const suiteState = hooks.setup ? hooks.setup() : undefined;
 
   try {
@@ -52,6 +54,7 @@ export function toBeFasterThan(callbackA: SyncCallback, callbackB: SyncCallback,
       durationsA, durationsB, count, errorCountA, errorCountB,
       allowedErrorRate, confidence, setupTeardownActive,
       removeOutliersEnabled: options.outliers === 'remove',
+      logDiagnostics,
     });
   } finally {
     if (hooks.teardown) hooks.teardown(suiteState);
@@ -79,6 +82,7 @@ export async function toResolveFasterThan(promiseA: AsyncCallback, promiseB: Asy
   setupEach?: (suiteState: unknown) => unknown,
   teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>,
   allowedErrorRate?: number,
+  logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
 }) {
   validateCallback(promiseA);
   validateCallback(promiseB);
@@ -88,6 +92,7 @@ export async function toResolveFasterThan(promiseA: AsyncCallback, promiseB: Asy
   const confidence = options.confidence ?? 0.95;
   const hooks: AsyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const logDiagnostics = options.logDiagnostics ?? 'WARN';
   const suiteState = hooks.setup ? await hooks.setup() : undefined;
 
   try {
@@ -108,6 +113,7 @@ export async function toResolveFasterThan(promiseA: AsyncCallback, promiseB: Asy
       durationsA, durationsB, count, errorCountA, errorCountB,
       allowedErrorRate, confidence, setupTeardownActive,
       removeOutliersEnabled: options.outliers === 'remove',
+      logDiagnostics,
     });
   } finally {
     if (hooks.teardown) await hooks.teardown(suiteState);

--- a/src/matchers-quantile.ts
+++ b/src/matchers-quantile.ts
@@ -18,6 +18,7 @@ export function toCompleteWithinQuantile(callback: SyncCallback, expectedDuratio
   setupEach?: (suiteState: unknown) => unknown,
   teardownEach?: (suiteState: unknown, iterState: unknown) => void,
   allowedErrorRate?: number,
+  logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
 }) {
   validateCallback(callback);
   validateDuration(expectedDurationInMilliseconds);
@@ -27,6 +28,7 @@ export function toCompleteWithinQuantile(callback: SyncCallback, expectedDuratio
   const quantile = options.quantile;
   const hooks: SyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const logDiagnostics = options.logDiagnostics ?? 'WARN';
   const suiteState = hooks.setup ? hooks.setup() : undefined;
 
   try {
@@ -39,7 +41,7 @@ export function toCompleteWithinQuantile(callback: SyncCallback, expectedDuratio
     }
 
     const setupTeardownActive = !!(hooks.setup || hooks.teardown || hooks.setupEach || hooks.teardownEach);
-    return processQuantileResults({durations, count, quantile, errorCount, allowedErrorRate, expectedDurationInMilliseconds, setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove'});
+    return processQuantileResults({durations, count, quantile, errorCount, allowedErrorRate, expectedDurationInMilliseconds, setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove', logDiagnostics});
   } finally {
     if (hooks.teardown) hooks.teardown(suiteState);
   }
@@ -61,6 +63,7 @@ export async function toResolveWithinQuantile(promise: AsyncCallback, expectedDu
   setupEach?: (suiteState: unknown) => unknown,
   teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>,
   allowedErrorRate?: number,
+  logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
 }) {
   validateCallback(promise);
   validateDuration(expectedDurationInMilliseconds);
@@ -70,6 +73,7 @@ export async function toResolveWithinQuantile(promise: AsyncCallback, expectedDu
   const quantile = options.quantile;
   const hooks: AsyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const logDiagnostics = options.logDiagnostics ?? 'WARN';
   const suiteState = hooks.setup ? await hooks.setup() : undefined;
 
   try {
@@ -82,7 +86,7 @@ export async function toResolveWithinQuantile(promise: AsyncCallback, expectedDu
     }
 
     const setupTeardownActive = !!(hooks.setup || hooks.teardown || hooks.setupEach || hooks.teardownEach);
-    return processQuantileResults({durations, count, quantile, errorCount, allowedErrorRate, expectedDurationInMilliseconds, setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove'});
+    return processQuantileResults({durations, count, quantile, errorCount, allowedErrorRate, expectedDurationInMilliseconds, setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove', logDiagnostics});
   } finally {
     if (hooks.teardown) await hooks.teardown(suiteState);
   }

--- a/src/matchers-throughput.ts
+++ b/src/matchers-throughput.ts
@@ -42,6 +42,7 @@ export function toAchieveOpsPerSecond(callback: SyncCallback, expectedOpsPerSeco
   setupEach?: (suiteState: unknown) => unknown,
   teardownEach?: (suiteState: unknown, iterState: unknown) => void,
   allowedErrorRate?: number,
+  logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
 }) {
   validateCallback(callback);
   validateExpectedOpsPerSecond(expectedOpsPerSecond);
@@ -49,6 +50,7 @@ export function toAchieveOpsPerSecond(callback: SyncCallback, expectedOpsPerSeco
 
   const hooks: SyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const logDiagnostics = options.logDiagnostics ?? 'WARN';
   const suiteState = hooks.setup ? hooks.setup() : undefined;
 
   try {
@@ -62,6 +64,7 @@ export function toAchieveOpsPerSecond(callback: SyncCallback, expectedOpsPerSeco
       durations, totalOps, errorCount, allowedErrorRate,
       expectedOpsPerSecond, duration: options.duration,
       setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove',
+      logDiagnostics,
     });
   } finally {
     if (hooks.teardown) hooks.teardown(suiteState);
@@ -107,6 +110,7 @@ export async function toResolveAtOpsPerSecond(callback: AsyncCallback, expectedO
   setupEach?: (suiteState: unknown) => unknown,
   teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>,
   allowedErrorRate?: number,
+  logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
 }) {
   validateCallback(callback);
   validateExpectedOpsPerSecond(expectedOpsPerSecond);
@@ -114,6 +118,7 @@ export async function toResolveAtOpsPerSecond(callback: AsyncCallback, expectedO
 
   const hooks: AsyncHooks = options;
   const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const logDiagnostics = options.logDiagnostics ?? 'WARN';
   const suiteState = hooks.setup ? await hooks.setup() : undefined;
 
   try {
@@ -127,6 +132,7 @@ export async function toResolveAtOpsPerSecond(callback: AsyncCallback, expectedO
       durations, totalOps, errorCount, allowedErrorRate,
       expectedOpsPerSecond, duration: options.duration,
       setupTeardownActive, removeOutliersEnabled: options.outliers === 'remove',
+      logDiagnostics,
     });
   } finally {
     if (hooks.teardown) await hooks.teardown(suiteState);

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,3 +1,9 @@
+function validateLogDiagnostics(logDiagnostics: string | undefined): void {
+  if (logDiagnostics !== undefined && logDiagnostics !== 'INFO' && logDiagnostics !== 'WARN' && logDiagnostics !== 'FAIL') {
+    throw new Error(`jest-performance-matchers: logDiagnostics must be 'INFO', 'WARN', or 'FAIL', received '${logDiagnostics}'`);
+  }
+}
+
 export function validateCallback(callback: unknown): void {
   if (typeof callback !== 'function') {
     throw new TypeError(`jest-performance-matchers: expected value must be a function, received ${typeof callback}`);
@@ -39,7 +45,8 @@ export function validateQuantileOptions(options: {
   teardown?: unknown,
   setupEach?: unknown,
   teardownEach?: unknown,
-  allowedErrorRate?: number
+  allowedErrorRate?: number,
+  logDiagnostics?: string,
 }): void {
   if (!options || typeof options !== 'object') {
     throw new Error('jest-performance-matchers: options must be an object with iterations and quantile');
@@ -61,6 +68,7 @@ export function validateQuantileOptions(options: {
       throw new Error(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${options.allowedErrorRate}`);
     }
   }
+  validateLogDiagnostics(options.logDiagnostics);
   validateSetupTeardown(options);
 }
 
@@ -74,6 +82,7 @@ export function validateComparativeOptions(options: {
   setupEach?: unknown,
   teardownEach?: unknown,
   allowedErrorRate?: number,
+  logDiagnostics?: string,
 }): void {
   if (!options || typeof options !== 'object') {
     throw new Error('jest-performance-matchers: options must be an object with iterations');
@@ -97,6 +106,7 @@ export function validateComparativeOptions(options: {
       throw new Error(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${options.allowedErrorRate}`);
     }
   }
+  validateLogDiagnostics(options.logDiagnostics);
   validateSetupTeardown(options);
 }
 
@@ -115,6 +125,7 @@ export function validateThroughputOptions(options: {
   setupEach?: unknown,
   teardownEach?: unknown,
   allowedErrorRate?: number,
+  logDiagnostics?: string,
 }): void {
   if (!options || typeof options !== 'object') {
     throw new Error('jest-performance-matchers: options must be an object with duration');
@@ -133,5 +144,6 @@ export function validateThroughputOptions(options: {
       throw new Error(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${options.allowedErrorRate}`);
     }
   }
+  validateLogDiagnostics(options.logDiagnostics);
   validateSetupTeardown(options);
 }

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,6 +1,7 @@
 import {
   classifyRME, classifyCV, classifyMAD, classifySampleAdequacy,
-  generateInterpretation, generateComparisonInterpretation, generateThroughputInterpretation, formatTag, Tag
+  generateInterpretation, generateComparisonInterpretation, generateThroughputInterpretation,
+  hasWarningConditions, formatTag, Tag
 } from '../src/diagnostics';
 import {formatMs} from '../src/format';
 import {Stats, WelchTTestResult} from '../src/metrics';
@@ -959,5 +960,157 @@ describe("generateThroughputInterpretation", () => {
 
     // THEN it reports target met (since actualOps >= expectedOps)
     expect(actualResult).toContain('throughput target met');
+  });
+});
+
+describe("hasWarningConditions", () => {
+  function buildStats(overrides: Partial<Stats>): Stats {
+    return {
+      n: 31, min: 1, max: 10, mean: 5, median: 5, stddev: 1,
+      marginOfError: 0.35, relativeMarginOfError: 7.0,
+      confidenceInterval: [4.65, 5.35] as [number, number],
+      coefficientOfVariation: 0.05, skewness: 0, mad: 1, isSmallSample: false,
+      confidenceMethod: 'z', confidenceCriticalValue: 1.96, warnings: [],
+      ...overrides,
+    };
+  }
+
+  test("should return false when all conditions are clean", () => {
+    // GIVEN stats with all GOOD classifications and no error info
+    const givenStats = buildStats({});
+
+    // WHEN checking for warning conditions
+    const actualResult = hasWarningConditions(givenStats, 10);
+
+    // THEN no warnings are detected
+    expect(actualResult).toBe(false);
+  });
+
+  test("should return true when sample adequacy is POOR (n < 10)", () => {
+    // GIVEN stats with n < 10
+    const givenStats = buildStats({n: 5});
+
+    // WHEN checking for warning conditions
+    const actualResult = hasWarningConditions(givenStats);
+
+    // THEN a warning is detected
+    expect(actualResult).toBe(true);
+  });
+
+  test("should return true when RME is POOR (> 30%)", () => {
+    // GIVEN stats with POOR RME
+    const givenStats = buildStats({relativeMarginOfError: 35});
+
+    // WHEN checking for warning conditions
+    const actualResult = hasWarningConditions(givenStats);
+
+    // THEN a warning is detected
+    expect(actualResult).toBe(true);
+  });
+
+  test("should return true when CV is POOR (> 0.3)", () => {
+    // GIVEN stats with POOR CV
+    const givenStats = buildStats({coefficientOfVariation: 0.5});
+
+    // WHEN checking for warning conditions
+    const actualResult = hasWarningConditions(givenStats);
+
+    // THEN a warning is detected
+    expect(actualResult).toBe(true);
+  });
+
+  test("should return true when CI upper bound exceeds the threshold", () => {
+    // GIVEN stats with CI upper bound above the threshold
+    const givenStats = buildStats({confidenceInterval: [4.0, 6.0]});
+
+    // WHEN checking with threshold below CI upper
+    const actualResult = hasWarningConditions(givenStats, 5.5);
+
+    // THEN a warning is detected
+    expect(actualResult).toBe(true);
+  });
+
+  test("should return true when CI range is entirely above the threshold", () => {
+    // GIVEN stats with CI entirely above the threshold
+    const givenStats = buildStats({confidenceInterval: [6.0, 8.0]});
+
+    // WHEN checking with threshold below CI lower
+    const actualResult = hasWarningConditions(givenStats, 5.0);
+
+    // THEN a warning is detected
+    expect(actualResult).toBe(true);
+  });
+
+  test("should return true when error rate is non-zero", () => {
+    // GIVEN clean stats but non-zero error info
+    const givenStats = buildStats({});
+    const givenErrorInfo = {errorCount: 2, totalIterations: 31, allowedRate: 0.1};
+
+    // WHEN checking for warning conditions
+    const actualResult = hasWarningConditions(givenStats, undefined, givenErrorInfo);
+
+    // THEN a warning is detected
+    expect(actualResult).toBe(true);
+  });
+
+  test("should return false when errorInfo has zero errors", () => {
+    // GIVEN clean stats with zero-error errorInfo
+    const givenStats = buildStats({});
+    const givenErrorInfo = {errorCount: 0, totalIterations: 31, allowedRate: 0.1};
+
+    // WHEN checking for warning conditions
+    const actualResult = hasWarningConditions(givenStats, 10, givenErrorInfo);
+
+    // THEN no warnings are detected
+    expect(actualResult).toBe(false);
+  });
+
+  test("should return false when CI is null and no threshold", () => {
+    // GIVEN stats with null CI and no threshold
+    const givenStats = buildStats({confidenceInterval: null});
+
+    // WHEN checking without a threshold
+    const actualResult = hasWarningConditions(givenStats);
+
+    // THEN no warnings (CI check is skipped)
+    expect(actualResult).toBe(false);
+  });
+
+  test("should return false when RME and CV are null (mean ≈ 0)", () => {
+    // GIVEN stats where RME and CV are null
+    const givenStats = buildStats({
+      relativeMarginOfError: null, coefficientOfVariation: null,
+    });
+
+    // WHEN checking for warning conditions
+    const actualResult = hasWarningConditions(givenStats);
+
+    // THEN no warnings from null classifiers
+    expect(actualResult).toBe(false);
+  });
+
+  test("should return true when multiple warning conditions hold simultaneously", () => {
+    // GIVEN stats with POOR sample, POOR RME, POOR CV, and non-zero errors all together
+    const givenStats = buildStats({
+      n: 5, relativeMarginOfError: 50, coefficientOfVariation: 0.6,
+    });
+    const givenErrorInfo = {errorCount: 3, totalIterations: 8, allowedRate: 0.5};
+
+    // WHEN checking for warning conditions
+    const actualResult = hasWarningConditions(givenStats, 5.5, givenErrorInfo);
+
+    // THEN a warning is detected (short-circuits on the first match)
+    expect(actualResult).toBe(true);
+  });
+
+  test("should return false when threshold is undefined even with wide CI", () => {
+    // GIVEN stats with wide CI but no threshold provided
+    const givenStats = buildStats({confidenceInterval: [1, 100]});
+
+    // WHEN checking without a threshold
+    const actualResult = hasWarningConditions(givenStats);
+
+    // THEN no CI-related warning
+    expect(actualResult).toBe(false);
   });
 });

--- a/test/matchers-comparative.test.ts
+++ b/test/matchers-comparative.test.ts
@@ -629,7 +629,7 @@ describe("toBeFasterThan", () => {
       const actualResult = processComparativeResults({
         durationsA: givenFunctionADurations, durationsB: givenFunctionBDurations,
         count: 10, errorCountA: 2, errorCountB: 0,
-        allowedErrorRate: 0.3, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false,
+        allowedErrorRate: 0.3, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
       });
       const actualMessage = actualResult.message();
 
@@ -1033,7 +1033,7 @@ describe("processComparativeResults (unit tests)", () => {
     // WHEN processing comparative results with allowedErrorRate=0.1,
     const actualResult = processComparativeResults({
       durationsA: givenFunctionADurations, durationsB: givenFunctionBDurations, count: 5,
-      errorCountA: 3, errorCountB: 0, allowedErrorRate: 0.1, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false,
+      errorCountA: 3, errorCountB: 0, allowedErrorRate: 0.1, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN the result fails with an error rate exceeded message for Function A
@@ -1049,7 +1049,7 @@ describe("processComparativeResults (unit tests)", () => {
     // WHEN processing comparative results with allowedErrorRate=0.1,
     const actualResult = processComparativeResults({
       durationsA: givenFunctionADurations, durationsB: givenFunctionBDurations, count: 5,
-      errorCountA: 0, errorCountB: 3, allowedErrorRate: 0.1, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false,
+      errorCountA: 0, errorCountB: 3, allowedErrorRate: 0.1, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN the result fails with an error rate exceeded message for Function B
@@ -1065,7 +1065,7 @@ describe("processComparativeResults (unit tests)", () => {
     // WHEN processing comparative results,
     const actualResult = processComparativeResults({
       durationsA: givenFunctionADurations, durationsB: givenFunctionBDurations, count: 5,
-      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false,
+      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN the result fails with an insufficient data message for Function A
@@ -1081,7 +1081,7 @@ describe("processComparativeResults (unit tests)", () => {
     // WHEN processing comparative results,
     const actualResult = processComparativeResults({
       durationsA: givenFunctionADurations, durationsB: givenFunctionBDurations, count: 5,
-      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false,
+      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN the result fails with an insufficient data message for Function B
@@ -1096,7 +1096,7 @@ describe("processComparativeResults (unit tests)", () => {
     // WHEN processing comparative results,
     const actualResult = processComparativeResults({
       durationsA: givenData, durationsB: [...givenData], count: 5,
-      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false,
+      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN the result is not pass because there is no significant difference
@@ -1113,7 +1113,7 @@ describe("processComparativeResults (unit tests)", () => {
     // WHEN processing comparative results with zero means,
     const actualResult = processComparativeResults({
       durationsA: givenFunctionADurations, durationsB: givenFunctionBDurations, count: 5,
-      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false,
+      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
     const actualMessage = actualResult.message();
 
@@ -1130,7 +1130,7 @@ describe("processComparativeResults (unit tests)", () => {
     // WHEN processing comparative results with setupTeardownActive=true,
     const actualResult = processComparativeResults({
       durationsA: givenFunctionADurations, durationsB: givenFunctionBDurations, count: 5,
-      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: true, removeOutliersEnabled: false,
+      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: true, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN the message contains the setup/teardown active hint
@@ -1145,7 +1145,7 @@ describe("processComparativeResults (unit tests)", () => {
     // WHEN processing comparative results with errors within tolerance,
     const actualResult = processComparativeResults({
       durationsA: givenFunctionADurations, durationsB: givenFunctionBDurations, count: 5,
-      errorCountA: 1, errorCountB: 0, allowedErrorRate: 0.5, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false,
+      errorCountA: 1, errorCountB: 0, allowedErrorRate: 0.5, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
     const actualMessage = actualResult.message();
 
@@ -1162,12 +1162,143 @@ describe("processComparativeResults (unit tests)", () => {
     // WHEN processing comparative results,
     const actualResult = processComparativeResults({
       durationsA: givenFunctionADurations, durationsB: givenFunctionBDurations, count: 5,
-      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false,
+      errorCountA: 0, errorCountB: 0, allowedErrorRate: 0, confidence: 0.95, setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN pass is true because Function A is statistically significantly faster
     expect(actualResult.pass).toBe(true);
     // AND the negated message indicates Function A is faster (used when .not is applied)
     expect(actualResult.message()).toContain('expected Function A NOT to be faster than Function B');
+  });
+});
+
+describe("logDiagnostics option (toBeFasterThan)", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("should log via console.info on passing test when logDiagnostics is 'INFO'", () => {
+    // GIVEN Function A faster than Function B
+    const givenADurations = [5, 5, 5, 5, 5];
+    const givenBDurations = [15, 15, 15, 15, 15];
+    mockFunctionProcessTimesInterleaved(givenADurations, givenBDurations);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    expect(() => undefined).toBeFasterThan(() => undefined, {
+      iterations: 5, logDiagnostics: 'INFO',
+    });
+
+    // THEN console.info is called with the diagnostics block
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics:');
+  });
+
+  test("should log via console.warn on passing test with warnings (WARN level)", () => {
+    // GIVEN Function A faster than Function B with only 2 iterations (POOR sample)
+    const givenADurations = [5, 5];
+    const givenBDurations = [15, 15];
+    mockFunctionProcessTimesInterleaved(givenADurations, givenBDurations);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    // WHEN asserting with default logDiagnostics (WARN)
+    expect(() => undefined).toBeFasterThan(() => undefined, {iterations: 2});
+
+    // THEN console.warn is called because n=2 triggers POOR sample adequacy
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics (warnings detected):');
+  });
+
+  test("should not log on passing test when logDiagnostics is 'FAIL'", () => {
+    // GIVEN Function A faster than Function B with small sample
+    const givenADurations = [5, 5];
+    const givenBDurations = [15, 15];
+    mockFunctionProcessTimesInterleaved(givenADurations, givenBDurations);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'FAIL'
+    expect(() => undefined).toBeFasterThan(() => undefined, {
+      iterations: 2, logDiagnostics: 'FAIL',
+    });
+
+    // THEN no console output
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test("should not log on passing test when logDiagnostics is 'WARN' and no warnings", () => {
+    // GIVEN Function A faster than Function B with large, consistent sample (no warning conditions)
+    const givenADurations = Array(31).fill(5);
+    const givenBDurations = Array(31).fill(15);
+    mockFunctionProcessTimesInterleaved(givenADurations, givenBDurations);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with default logDiagnostics (WARN)
+    expect(() => undefined).toBeFasterThan(() => undefined, {iterations: 31});
+
+    // THEN no console output (no warning conditions on either side)
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test("should not log on failing test regardless of logDiagnostics level", () => {
+    // GIVEN Function A NOT faster than Function B (same speed)
+    const givenADurations = [10, 10, 10, 10, 10];
+    const givenBDurations = [10, 10, 10, 10, 10];
+    mockFunctionProcessTimesInterleaved(givenADurations, givenBDurations);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    expect(() => {
+      expect(() => undefined).toBeFasterThan(() => undefined, {
+        iterations: 5, logDiagnostics: 'INFO',
+      });
+    }).toThrow();
+
+    // THEN no console output
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("logDiagnostics option (toResolveFasterThan)", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("should log via console.info on passing async test when logDiagnostics is 'INFO'", async () => {
+    // GIVEN async Function A faster than Function B
+    const givenADurations = [5, 5, 5, 5, 5];
+    const givenBDurations = [15, 15, 15, 15, 15];
+    mockFunctionProcessTimesInterleaved(givenADurations, givenBDurations);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    await expect(async () => undefined).toResolveFasterThan(async () => undefined, {
+      iterations: 5, logDiagnostics: 'INFO',
+    });
+
+    // THEN console.info is called
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics:');
+  });
+
+  test("should not log on failing async test with logDiagnostics 'INFO'", async () => {
+    // GIVEN async functions with same speed (no significant difference)
+    const givenADurations = [10, 10, 10, 10, 10];
+    const givenBDurations = [10, 10, 10, 10, 10];
+    mockFunctionProcessTimesInterleaved(givenADurations, givenBDurations);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    await expect(
+      expect(async () => undefined).toResolveFasterThan(async () => undefined, {
+        iterations: 5, logDiagnostics: 'INFO',
+      })
+    ).rejects.toThrow();
+
+    // THEN no console output
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/matchers-quantile.test.ts
+++ b/test/matchers-quantile.test.ts
@@ -2365,3 +2365,173 @@ describe("Test jest expect.toResolveWithinQuantile assertion", () => {
   });
 });
 
+describe("logDiagnostics option (sync)", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("should log via console.info on passing test when logDiagnostics is 'INFO'", () => {
+    // GIVEN a function that passes and logDiagnostics is INFO
+    const givenDuration = 10;
+    const givenIterations = 5;
+    mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+      iterations: givenIterations, quantile: 100, logDiagnostics: 'INFO',
+    });
+
+    // THEN console.info is called with the diagnostics block
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics:');
+    expect(infoSpy.mock.calls[0][0]).toContain('Statistics');
+  });
+
+  test("should log via console.warn on passing test when logDiagnostics is 'WARN' and warnings detected", () => {
+    // GIVEN a function that passes with small sample (POOR sample adequacy)
+    const givenDuration = 10;
+    const givenIterations = 3;
+    mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'WARN' (n=3 triggers POOR sample adequacy)
+    expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+      iterations: givenIterations, quantile: 100, logDiagnostics: 'WARN',
+    });
+
+    // THEN console.warn is called with warnings detected
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics (warnings detected):');
+  });
+
+  test("should not log on passing test when logDiagnostics is 'WARN' and no warnings", () => {
+    // GIVEN a function that passes with good stats (many consistent iterations)
+    const givenDuration = 10;
+    const givenIterations = 31;
+    mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'WARN'
+    expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+      iterations: givenIterations, quantile: 100, logDiagnostics: 'WARN',
+    });
+
+    // THEN no console output
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test("should not log on passing test when logDiagnostics is 'FAIL'", () => {
+    // GIVEN a function that passes with small sample
+    const givenDuration = 10;
+    const givenIterations = 3;
+    mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'FAIL'
+    expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+      iterations: givenIterations, quantile: 100, logDiagnostics: 'FAIL',
+    });
+
+    // THEN no console output even though warnings exist
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test("should not log on failing test regardless of logDiagnostics level", () => {
+    // GIVEN a function that exceeds the threshold
+    const givenDuration = 10;
+    const givenIterations = 5;
+    mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration + 5));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO' (strongest output level)
+    expect(() => {
+      expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+        iterations: givenIterations, quantile: 100, logDiagnostics: 'INFO',
+      });
+    }).toThrow();
+
+    // THEN no console output — diagnostics are in the error message
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test("should default to 'WARN' when logDiagnostics is omitted", () => {
+    // GIVEN a function that passes with small sample (POOR sample adequacy)
+    const givenDuration = 10;
+    const givenIterations = 3;
+    mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    // WHEN asserting without logDiagnostics option
+    expect(() => undefined).toCompleteWithinQuantile(givenDuration, {
+      iterations: givenIterations, quantile: 100,
+    });
+
+    // THEN console.warn is called (WARN is default, and warnings are present)
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("logDiagnostics option (async)", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("should log via console.info on passing async test when logDiagnostics is 'INFO'", async () => {
+    // GIVEN an async function that passes
+    const givenDuration = 10;
+    const givenIterations = 5;
+    mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    await expect(async () => undefined).toResolveWithinQuantile(givenDuration, {
+      iterations: givenIterations, quantile: 100, logDiagnostics: 'INFO',
+    });
+
+    // THEN console.info is called
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics:');
+  });
+
+  test("should log via console.warn on passing async test with warnings", async () => {
+    // GIVEN an async function that passes with small sample
+    const givenDuration = 10;
+    const givenIterations = 3;
+    mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    // WHEN asserting with default logDiagnostics (WARN)
+    await expect(async () => undefined).toResolveWithinQuantile(givenDuration, {
+      iterations: givenIterations, quantile: 100,
+    });
+
+    // THEN console.warn is called
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("should not log on failing async test with logDiagnostics 'INFO'", async () => {
+    // GIVEN an async function that exceeds the threshold
+    const givenDuration = 10;
+    const givenIterations = 5;
+    mockFunctionProcessTimes(Array(givenIterations).fill(givenDuration + 5));
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    await expect(
+      expect(async () => undefined).toResolveWithinQuantile(givenDuration, {
+        iterations: givenIterations, quantile: 100, logDiagnostics: 'INFO',
+      })
+    ).rejects.toThrow();
+
+    // THEN no console output
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});
+

--- a/test/matchers-throughput.test.ts
+++ b/test/matchers-throughput.test.ts
@@ -1,7 +1,7 @@
 import '../src/main';
 import {processThroughputResults} from '../src/helpers';
 import {mockThroughputTimings} from './test-utils';
-import {printExpected, printReceived} from "jest-matcher-utils";
+import {printExpected} from "jest-matcher-utils";
 
 describe("toAchieveOpsPerSecond", () => {
   beforeEach(() => {
@@ -155,7 +155,7 @@ describe("toAchieveOpsPerSecond", () => {
       }
 
       // THEN the failure message includes a throughput confidence interval
-      expect(actualMessage).toMatch(/CI 95%: \[\d+, \d+\] ops\/sec/);
+      expect(actualMessage).toMatch(/CI 95%: \[\d+, \d+] ops\/sec/);
     });
 
     test("should show target shortfall info when below target", () => {
@@ -413,7 +413,7 @@ describe("toAchieveOpsPerSecond", () => {
       }).toAchieveOpsPerSecond(1, {
         duration: givenDuration,
         setup: () => givenSuiteState,
-        setupEach: (suiteState) => `foo-iter-${++callCount}`,
+        setupEach: () => `foo-iter-${++callCount}`,
         teardownEach: (suiteState, iterState) => {
           actualTeardownArgs.push([suiteState, iterState]);
         },
@@ -634,8 +634,8 @@ describe("toAchieveOpsPerSecond", () => {
 
     test("should throw validation error when options is null", () => {
       expect(() => {
-        // @ts-expect-error - intentionally passing null for testing
-        expect(() => undefined).toAchieveOpsPerSecond(100, null);
+        // intentionally passing null for testing
+        expect(() => undefined).toAchieveOpsPerSecond(100, null as unknown as {duration: number});
       }).toThrow("jest-performance-matchers: options must be an object with duration");
     });
 
@@ -1008,7 +1008,7 @@ describe("processThroughputResults", () => {
     const actualResult = processThroughputResults({
       durations: [], totalOps: 5, errorCount: 5, allowedErrorRate: 1,
       expectedOpsPerSecond: 100, duration: 1000,
-      setupTeardownActive: false, removeOutliersEnabled: false,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN the result fails with an all-failed error message
@@ -1021,7 +1021,7 @@ describe("processThroughputResults", () => {
     const actualResult = processThroughputResults({
       durations: [10, 10], totalOps: 5, errorCount: 3, allowedErrorRate: 0.1,
       expectedOpsPerSecond: 1, duration: 1000,
-      setupTeardownActive: false, removeOutliersEnabled: false,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN the result fails with an error rate exceeded message
@@ -1034,10 +1034,141 @@ describe("processThroughputResults", () => {
     const actualResult = processThroughputResults({
       durations: [10], totalOps: 1, errorCount: 0, allowedErrorRate: 0,
       expectedOpsPerSecond: 1, duration: 1000,
-      setupTeardownActive: false, removeOutliersEnabled: false,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
     });
 
     // THEN the result passes
     expect(actualResult.pass).toBe(true);
+  });
+});
+
+describe("logDiagnostics option (toAchieveOpsPerSecond)", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("should log via console.info on passing test when logDiagnostics is 'INFO'", () => {
+    // GIVEN a function that achieves the target
+    const givenOpDurations = [10, 10, 10, 10, 10];
+    const givenDuration = 1000;
+    mockThroughputTimings(givenOpDurations, givenDuration);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    expect(() => undefined).toAchieveOpsPerSecond(5, {
+      duration: givenDuration, logDiagnostics: 'INFO',
+    });
+
+    // THEN console.info is called with the diagnostics block
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics:');
+  });
+
+  test("should log via console.warn on passing test with warnings (default WARN)", () => {
+    // GIVEN a function with only 1 operation (POOR sample adequacy)
+    const givenOpDurations = [10];
+    const givenDuration = 1000;
+    mockThroughputTimings(givenOpDurations, givenDuration);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    // WHEN asserting without logDiagnostics (defaults to WARN)
+    expect(() => undefined).toAchieveOpsPerSecond(1, {duration: givenDuration});
+
+    // THEN console.warn is called because n=1 triggers POOR sample adequacy
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics (warnings detected):');
+  });
+
+  test("should not log on passing test when logDiagnostics is 'FAIL'", () => {
+    // GIVEN a function with only 1 operation (POOR sample adequacy)
+    const givenOpDurations = [10];
+    const givenDuration = 1000;
+    mockThroughputTimings(givenOpDurations, givenDuration);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'FAIL'
+    expect(() => undefined).toAchieveOpsPerSecond(1, {
+      duration: givenDuration, logDiagnostics: 'FAIL',
+    });
+
+    // THEN no console output
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test("should not log on passing test when logDiagnostics is 'WARN' and no warnings", () => {
+    // GIVEN a function with 31 consistent operations (no warning conditions)
+    const givenOpDurations = Array(31).fill(10);
+    const givenDuration = 1000;
+    mockThroughputTimings(givenOpDurations, givenDuration);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with default logDiagnostics (WARN)
+    expect(() => undefined).toAchieveOpsPerSecond(5, {duration: givenDuration});
+
+    // THEN no console output (no warning conditions detected)
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test("should not log on failing test regardless of logDiagnostics level", () => {
+    // GIVEN a function that does NOT achieve the target
+    const givenOpDurations = [10, 10, 10, 10, 10];
+    const givenDuration = 1000;
+    mockThroughputTimings(givenOpDurations, givenDuration);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO' for an impossible target
+    expect(() => {
+      expect(() => undefined).toAchieveOpsPerSecond(10000, {
+        duration: givenDuration, logDiagnostics: 'INFO',
+      });
+    }).toThrow();
+
+    // THEN no console output
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("logDiagnostics option (toResolveAtOpsPerSecond)", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("should log via console.info on passing async test when logDiagnostics is 'INFO'", async () => {
+    // GIVEN an async function that achieves the target
+    const givenOpDurations = [10, 10, 10, 10, 10];
+    const givenDuration = 1000;
+    mockThroughputTimings(givenOpDurations, givenDuration);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    await expect(async () => undefined).toResolveAtOpsPerSecond(5, {
+      duration: givenDuration, logDiagnostics: 'INFO',
+    });
+
+    // THEN console.info is called
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics:');
+  });
+
+  test("should not log on failing async test with logDiagnostics 'INFO'", async () => {
+    // GIVEN an async function that does NOT achieve the target
+    const givenOpDurations = [10, 10, 10, 10, 10];
+    const givenDuration = 1000;
+    mockThroughputTimings(givenOpDurations, givenDuration);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting for an impossible target
+    await expect(
+      expect(async () => undefined).toResolveAtOpsPerSecond(10000, {
+        duration: givenDuration, logDiagnostics: 'INFO',
+      })
+    ).rejects.toThrow();
+
+    // THEN no console output
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/validators.test.ts
+++ b/test/validators.test.ts
@@ -297,6 +297,21 @@ describe("Input validation", () => {
         });
       }).toThrowError(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${givenAllowedErrorRate}`);
     });
+
+    test("should throw a validation error when logDiagnostics is an invalid value", () => {
+      // GIVEN an invalid logDiagnostics value
+      const givenLogDiagnostics = 'DEBUG';
+
+      // WHEN asserting with the invalid value,
+      // THEN a descriptive error is thrown
+      expect(() => {
+        expect(() => undefined).toCompleteWithinQuantile(10, {
+          iterations: 5,
+          quantile: 95,
+          logDiagnostics: givenLogDiagnostics as 'INFO',
+        });
+      }).toThrowError(`jest-performance-matchers: logDiagnostics must be 'INFO', 'WARN', or 'FAIL', received '${givenLogDiagnostics}'`);
+    });
   });
 
   describe("toResolveWithinQuantile", () => {
@@ -418,6 +433,21 @@ describe("Input validation", () => {
           allowedErrorRate: givenAllowedErrorRate
         });
       }).rejects.toThrowError(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${givenAllowedErrorRate}`);
+    });
+
+    test("should throw a validation error when logDiagnostics is an invalid value", async () => {
+      // GIVEN an invalid logDiagnostics value
+      const givenLogDiagnostics = 'VERBOSE';
+
+      // WHEN asserting with the invalid value,
+      // THEN a descriptive error is thrown
+      await expect(async () => {
+        await expect(async () => Promise.resolve()).toResolveWithinQuantile(10, {
+          iterations: 5,
+          quantile: 95,
+          logDiagnostics: givenLogDiagnostics as 'INFO',
+        });
+      }).rejects.toThrowError(`jest-performance-matchers: logDiagnostics must be 'INFO', 'WARN', or 'FAIL', received '${givenLogDiagnostics}'`);
     });
   });
 
@@ -642,6 +672,19 @@ describe("Input validation", () => {
       expect(() => {
         expect(() => undefined).toBeFasterThan(() => undefined, {iterations: 5, allowedErrorRate: givenAllowedErrorRate});
       }).toThrowError(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${givenAllowedErrorRate}`);
+    });
+
+    test("should throw an error when logDiagnostics is an invalid value", () => {
+      // GIVEN an invalid logDiagnostics value
+      const givenLogDiagnostics = 'TRACE';
+
+      // WHEN asserting toBeFasterThan
+      // THEN expect a descriptive error
+      expect(() => {
+        expect(() => undefined).toBeFasterThan(() => undefined, {
+          iterations: 5, logDiagnostics: givenLogDiagnostics as 'INFO',
+        });
+      }).toThrowError(`jest-performance-matchers: logDiagnostics must be 'INFO', 'WARN', or 'FAIL', received '${givenLogDiagnostics}'`);
     });
 
     test("should throw an error when setup is not a function", () => {
@@ -906,6 +949,19 @@ describe("Input validation", () => {
       }).rejects.toThrowError(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${givenAllowedErrorRate}`);
     });
 
+    test("should throw an error when logDiagnostics is an invalid value", async () => {
+      // GIVEN an invalid logDiagnostics value
+      const givenLogDiagnostics = 'TRACE';
+
+      // WHEN asserting toResolveFasterThan
+      // THEN expect a descriptive error
+      await expect(async () => {
+        await expect(async () => Promise.resolve()).toResolveFasterThan(async () => Promise.resolve(), {
+          iterations: 5, logDiagnostics: givenLogDiagnostics as 'INFO',
+        });
+      }).rejects.toThrowError(`jest-performance-matchers: logDiagnostics must be 'INFO', 'WARN', or 'FAIL', received '${givenLogDiagnostics}'`);
+    });
+
     test("should throw an error when setup is not a function", async () => {
       // GIVEN a non-function setup
       const givenSetup = "foo-not-a-function";
@@ -976,6 +1032,36 @@ describe("Input validation", () => {
         // @ts-expect-error - intentionally passing invalid options for testing
         await expect(async () => Promise.resolve()).toResolveFasterThan(async () => Promise.resolve(), givenOptions);
       }).rejects.toThrowError("jest-performance-matchers: options must be an object with iterations");
+    });
+  });
+
+  describe("toAchieveOpsPerSecond", () => {
+    test("should throw an error when logDiagnostics is an invalid value", () => {
+      // GIVEN an invalid logDiagnostics value
+      const givenLogDiagnostics = 'TRACE';
+
+      // WHEN asserting toAchieveOpsPerSecond
+      // THEN expect a descriptive error
+      expect(() => {
+        expect(() => undefined).toAchieveOpsPerSecond(100, {
+          duration: 1000, logDiagnostics: givenLogDiagnostics as 'INFO',
+        });
+      }).toThrowError(`jest-performance-matchers: logDiagnostics must be 'INFO', 'WARN', or 'FAIL', received '${givenLogDiagnostics}'`);
+    });
+  });
+
+  describe("toResolveAtOpsPerSecond", () => {
+    test("should throw an error when logDiagnostics is an invalid value", async () => {
+      // GIVEN an invalid logDiagnostics value
+      const givenLogDiagnostics = 'TRACE';
+
+      // WHEN asserting toResolveAtOpsPerSecond
+      // THEN expect a descriptive error
+      await expect(async () => {
+        await expect(async () => Promise.resolve()).toResolveAtOpsPerSecond(100, {
+          duration: 1000, logDiagnostics: givenLogDiagnostics as 'INFO',
+        });
+      }).rejects.toThrowError(`jest-performance-matchers: logDiagnostics must be 'INFO', 'WARN', or 'FAIL', received '${givenLogDiagnostics}'`);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `logDiagnostics?: 'INFO' | 'WARN' | 'FAIL'` option (default `'WARN'`) to all six multi-iteration matchers: `toCompleteWithinQuantile`, `toResolveWithinQuantile`, `toBeFasterThan`, `toResolveFasterThan`, `toAchieveOpsPerSecond`, `toResolveAtOpsPerSecond`
- On passing tests: `WARN` logs diagnostics via `console.warn` when warning conditions are detected; `INFO` always logs via `console.info`; `FAIL` preserves prior behavior (no console output)
- On failing tests: diagnostics always appear in the failure message, regardless of level

Warning conditions detected by the new `hasWarningConditions()` helper:
- POOR sample adequacy (n < 10)
- POOR RME (> 30%)
- POOR CV (> 0.3)
- CI upper bound exceeding threshold
- Non-zero error rate

## Test plan

- [x] 632 tests pass (3 new integration + unit tests added)
- [x] 100% statement + branch coverage
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] SonarCloud analysis clean on all changed files (MAIN + TEST scope)
- [x] Validation tests added for invalid `logDiagnostics` values across all validator functions

Closes #72