### PR TITLE
feat: add toHaveHigherThroughputThan comparative throughput matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ expect(() => quicksort(data))
 // Assert your parser sustains at least 10,000 ops/sec over a 1-second window
 expect(() => parseJSON(payload))
     .toAchieveOpsPerSecond(10000, { duration: 1000, warmup: 100 });
+
+// Prove your new serializer has statistically higher throughput than the baseline
+expect(() => fastSerialize(payload))
+    .toHaveHigherThroughputThan(() => baselineSerialize(payload), { duration: 1000, warmup: 100 });
 ```
 
 ## What is this for?
@@ -161,6 +165,15 @@ expect(() => optimizedParser(input))
 await expect(async () => await queryWithIndex(db, id))
     .toResolveFasterThan(async () => await queryFullScan(db, id), {
         iterations: 50, warmup: 3, outliers: 'remove'
+    });
+```
+
+### Throughput comparison
+
+```ts
+expect(() => fastSerialize(payload))
+    .toHaveHigherThroughputThan(() => baselineSerialize(payload), {
+        duration: 1000, warmup: 100, outliers: 'remove'
     });
 ```
 
@@ -369,6 +382,56 @@ await expect(async () => {
 }).not.toResolveAtOpsPerSecond(10000, { duration: 1000 });
 ```
 
+### `.toHaveHigherThroughputThan(comparisonFn, options)`
+
+Assert that a synchronous function has statistically higher throughput than another using Welch's t-test. Each function runs independently for the specified `duration` window, collecting per-operation timings — then Welch's t-test determines whether Function A has significantly lower per-op time (= higher throughput) than Function B:
+
+```ts
+// Basic — prove the new serializer has higher throughput than the baseline
+expect(() => fastSerialize(payload))
+    .toHaveHigherThroughputThan(() => baselineSerialize(payload), { duration: 1000 });
+
+// With warmup — exclude JIT compilation and cache warming
+expect(() => fastSerialize(payload))
+    .toHaveHigherThroughputThan(() => baselineSerialize(payload), { duration: 1000, warmup: 100 });
+
+// With outlier removal — filter GC pauses before comparing
+expect(() => fastSerialize(payload))
+    .toHaveHigherThroughputThan(() => baselineSerialize(payload), { duration: 1000, outliers: 'remove' });
+
+// With custom confidence — require 99% confidence instead of 95%
+expect(() => fastSerialize(payload))
+    .toHaveHigherThroughputThan(() => baselineSerialize(payload), { duration: 1000, confidence: 0.99 });
+
+// Negation — assert Function A is NOT higher-throughput than Function B
+expect(() => legacyProcess(data))
+    .not.toHaveHigherThroughputThan(() => optimizedProcess(data), { duration: 1000 });
+
+// With error tolerance — tolerate up to 5% of operations throwing
+expect(() => processUnstable(data))
+    .toHaveHigherThroughputThan(() => processStable(data), { duration: 1000, allowedErrorRate: 0.05 });
+```
+
+### `.toResolveWithHigherThroughputThan(comparisonFn, options)`
+
+Assert that an asynchronous function has statistically higher throughput than another using Welch's t-test. Same API as `.toHaveHigherThroughputThan`, but for promise-returning functions:
+
+```ts
+// Basic
+await expect(async () => await cachedFetch(url))
+    .toResolveWithHigherThroughputThan(async () => await uncachedFetch(url), { duration: 2000 });
+
+// With warmup and outlier removal
+await expect(async () => await cachedFetch(url))
+    .toResolveWithHigherThroughputThan(async () => await uncachedFetch(url), {
+        duration: 2000, warmup: 50, outliers: 'remove'
+    });
+
+// Negation
+await expect(async () => await slowHandler(req))
+    .not.toResolveWithHigherThroughputThan(async () => await fastHandler(req), { duration: 1000 });
+```
+
 ### Throughput options reference
 
 | Option | Type | Required | Description |
@@ -441,6 +504,24 @@ expect((conn: DbConnection, data: Row[]) => {
 ```
 
 Setup, teardown, setupEach, and teardownEach time is excluded from measurements. If any throws, the test fails immediately — these are test infrastructure errors, not tolerated failures.
+
+### Comparative throughput options reference
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `duration` | `number` | Yes | Time window in milliseconds applied to each function independently (e.g., `1000` for 1 second each) |
+| `warmup` | `number` | No | Warmup iterations to run before measurement (default: `0`). Interleaved between A and B |
+| `confidence` | `number` | No | Significance level for the t-test, between 0 and 1 exclusive (default: `0.95`). Higher values require stronger evidence |
+| `outliers` | `'remove' \| 'keep'` | No | Whether to remove IQR-based outliers per function before comparison (default: `'keep'`). Outlier removal cleans per-op stats; total ops count is preserved |
+| `setup` | `() => T` | No | Called **once** before all operations. Return value is shared by both functions via `setupEach`, callbacks, and `teardown`. Errors are fatal |
+| `teardown` | `(suiteState: T) => void` | No | Called **once** after both measurement windows (in a `finally` block). Receives the `setup` return value. Errors are fatal |
+| `setupEach` | `(suiteState: T) => U` | No | Called before **each operation** (including warmup), not timed. Its return value is passed to the callback and `teardownEach`. Errors are fatal |
+| `teardownEach` | `(suiteState: T, iterState: U) => void` | No | Called after **each operation** (including warmup), not timed. Receives both `setup` and `setupEach` return values. Errors are fatal |
+| `allowedErrorRate` | `number` | No | Fraction of operations allowed to throw per function (0–1, default: `0`). Error rates are checked independently for each function. Setup/teardown errors are always fatal |
+
+> **Execution model:** Warmup iterations are interleaved (A, B, A, B, ...) so neither function gets a cache-warming advantage. Measurement then runs Function A for the full `duration` window, then Function B for the full `duration` window — each independently collects per-operation timings. Welch's t-test on the per-op durations determines whether A's mean is significantly lower than B's (lower per-op time = higher throughput). Unequal sample sizes are expected (the faster function completes more ops in the same window) and handled natively by Welch's t-test.
+
+> **Note:** For async matchers (`toResolveWithHigherThroughputThan`), `setup` and `setupEach` may return a `Promise`, and `teardown`/`teardownEach` may return a `Promise`.
 
 ### Quantile options reference
 
@@ -597,6 +678,45 @@ The comparative diagnostics include:
 - **Per-function stats** — full diagnostics for each function (same format as quantile matchers: mean, CI, RME, CV, MAD, distribution, shape, interpretation)
 - **Mean difference** — raw difference in milliseconds and as a percentage
 - **Welch's t-test** — t-statistic, degrees of freedom (Welch-Satterthwaite), and one-sided p-value
+
+### Comparative throughput matcher diagnostics
+
+When a comparative throughput matcher (`toHaveHigherThroughputThan` / `toResolveWithHigherThroughputThan`) fails, it outputs per-function throughput stats and a statistical comparison framed in ops/sec:
+
+```
+expected Function A to have higher throughput than Function B,
+but no statistically significant difference was found (p=0.1410 >= α=0.05)
+
+--- Function A ---
+Throughput: 8,432 ops/sec over 1,000ms (8,432 total operations)
+  CI 95%: [8,105, 8,759] ops/sec
+
+Per-operation timing (n=8432): mean=0.119ms, median=0.108ms, stddev=0.042ms, MAD=0.015ms
+  CI 95%: [0.118, 0.120]ms | RME: 0.89% [GOOD <10%] | CV: 0.35 [POOR >0.3]
+  ...
+
+--- Function B ---
+Throughput: 8,210 ops/sec over 1,000ms (8,210 total operations)
+  CI 95%: [7,891, 8,534] ops/sec
+  ...
+
+--- Comparison ---
+Throughput: A=8432 ops/sec, B=8210 ops/sec — Function A is higher by 222 ops/sec
+Welch's t-test: t=-1.08, df=188.3, p=0.1410 (one-sided)
+Confidence interval for per-op difference: 95% [-0.004, 0.001]ms
+Result: no statistically significant evidence that Function A has higher throughput
+  than Function B (8432 vs 8210 ops/sec, p=0.1410 >= α=0.05). Function A trends
+  higher by 222 ops/sec (2.7%) but the difference could be due to chance —
+  increase duration for more statistical power
+```
+
+The comparative throughput diagnostics include:
+- **Per-function throughput** — achieved ops/sec, measurement duration, total operations completed, and throughput CI
+- **Per-operation timing** — full per-op stats for each function (mean, CI, RME, CV, MAD, distribution, shape)
+- **Throughput difference** — raw difference in ops/sec with direction (higher/lower/identical)
+- **Welch's t-test** — t-statistic, degrees of freedom, one-sided p-value on per-op durations
+- **Confidence interval for per-op difference** — if this interval excludes zero, the functions have meaningfully different per-operation timings
+- **Result interpretation** — considers data reliability (POOR RME warnings), statistical significance, and practical significance (percentage difference in throughput)
 - **Confidence interval for the difference** — if this interval excludes zero, the functions have meaningfully different performance
 - **Result interpretation** — considers data reliability (POOR RME warnings), statistical significance (p-value vs α), and practical significance (percentage difference)
 

--- a/examples/comparative-throughput.test.ts
+++ b/examples/comparative-throughput.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Examples: toHaveHigherThroughputThan / toResolveWithHigherThroughputThan
+ *
+ * Comparative throughput matchers — statistically prove that one function
+ * sustains higher throughput (ops/sec) than another using Welch's t-test on
+ * per-operation durations. Each function runs independently for the specified
+ * `duration` window; faster functions complete more ops (unequal sample
+ * sizes are handled natively by Welch's t-test).
+ */
+import '../src/main';
+
+// --- Basic comparison ---
+
+test('Map.get has higher throughput than Array.find', () => {
+  // Prepare a Map and an equivalent array for lookup comparison
+  const size = 10_000;
+  const keys = Array.from({length: size}, (_, i) => `key-${i}`);
+  const map = new Map(keys.map((k, i) => [k, i]));
+  const arr = keys.map((k, i) => ({key: k, value: i}));
+  const target = keys[size - 1];
+
+  // Function A: Map.get (O(1) average)
+  const mapLookup = () => {
+    map.get(target);
+  };
+
+  // Function B: Array.find (O(n) worst case)
+  const arrayFind = () => {
+    arr.find(item => item.key === target);
+  };
+
+  // Assert that Map.get has statistically higher throughput over a 500ms window
+  expect(mapLookup).toHaveHigherThroughputThan(arrayFind, {duration: 500, warmup: 50});
+});
+
+// --- With outlier removal ---
+
+test('Set.has has higher throughput than Array.includes (with outlier removal)', () => {
+  // Prepare shared string-keyed data structures (strings prevent JIT integer optimizations)
+  const size = 50_000;
+  const arr = Array.from({length: size}, (_, i) => `key-${i}`);
+  const set = new Set(arr);
+  const target = arr[size - 1]; // worst-case for Array.includes (full scan)
+
+  // Function A: Set.has (O(1) average)
+  const setLookup = () => {
+    set.has(target);
+  };
+
+  // Function B: Array.includes (O(n) — has to scan all 50,000 entries)
+  const arrayIncludes = () => {
+    arr.includes(target);
+  };
+
+  // Assert with outlier removal to filter GC pauses from per-op timing stats
+  expect(setLookup).toHaveHigherThroughputThan(arrayIncludes, {
+    duration: 500, warmup: 20, outliers: 'remove',
+  });
+});
+
+// --- With custom confidence ---
+
+test('hashing a short string has higher throughput than hashing a long one (99% confidence)', () => {
+  // Prepare short and long inputs with the same hashing algorithm
+  const shortInput = 'abc';
+  const longInput = 'a'.repeat(1_000);
+
+  // Function A: hash short string (small loop)
+  const hashShort = () => {
+    let h = 0;
+    for (let i = 0; i < shortInput.length; i++) h = (h * 31 + shortInput.charCodeAt(i)) | 0;
+    return h;
+  };
+
+  // Function B: hash long string (reliably ~300x more work per op)
+  const hashLong = () => {
+    let h = 0;
+    for (let i = 0; i < longInput.length; i++) h = (h * 31 + longInput.charCodeAt(i)) | 0;
+    return h;
+  };
+
+  // Assert at a stricter 99% confidence level — huge throughput gap makes this robust
+  expect(hashShort).toHaveHigherThroughputThan(hashLong, {
+    duration: 500, warmup: 50, confidence: 0.99, outliers: 'remove'
+  });
+});
+
+// --- With setupEach for fresh data each operation ---
+
+test('native sort has higher throughput than bubble sort with fresh arrays each op', () => {
+  // setupEach provides a fresh unsorted array for each operation (not timed)
+  const setupEach = () => Array.from({length: 200}, () => Math.random());
+
+  // Function A: native Array.sort on fresh data
+  const nativeSort = (_suite: unknown, iterData: unknown) => {
+    const arr = iterData as number[];
+    arr.sort((a, b) => a - b);
+  };
+
+  // Function B: naive bubble sort on fresh data (intentionally slow)
+  const bubbleSort = (_suite: unknown, iterData: unknown) => {
+    const arr = iterData as number[];
+    for (let i = 0; i < arr.length; i++) {
+      for (let j = 0; j < arr.length - i - 1; j++) {
+        if (arr[j] > arr[j + 1]) [arr[j], arr[j + 1]] = [arr[j + 1], arr[j]];
+      }
+    }
+  };
+
+  // Assert that native sort has statistically higher throughput
+  expect(nativeSort).toHaveHigherThroughputThan(bubbleSort, {
+    duration: 500, warmup: 5, setupEach,
+  });
+});
+
+// --- Negation: proving a slower implementation does NOT have higher throughput ---
+
+test('linear array scan does NOT have higher throughput than Map.get', () => {
+  // Prepare equivalent Map and array lookups
+  const size = 5_000;
+  const keys = Array.from({length: size}, (_, i) => `key-${i}`);
+  const map = new Map(keys.map((k, i) => [k, i]));
+  const arr = keys.map((k, i) => ({key: k, value: i}));
+  const target = keys[size - 1]; // worst-case for array scan
+
+  // Function A: array scan (O(n) — expected to be slower)
+  const arrayScan = () => {
+    arr.find(item => item.key === target);
+  };
+
+  // Function B: Map.get (O(1) average — expected to be faster)
+  const mapGet = () => {
+    map.get(target);
+  };
+
+  // Assert A is NOT higher-throughput than B (guards against regressions in Map usage)
+  expect(arrayScan).not.toHaveHigherThroughputThan(mapGet, {duration: 300});
+});
+
+// --- Asynchronous comparison ---
+
+test('cached async lookup has higher throughput than uncached', async () => {
+  const cache = new Map<string, number>();
+
+  // Function A: cached lookup (instant)
+  const cachedLookup = async () => {
+    if (!cache.has('key')) cache.set('key', 42);
+    return cache.get('key');
+  };
+
+  // Function B: uncached async operation (simulates slow I/O)
+  const uncachedLookup = async () => {
+    await new Promise(resolve => setTimeout(resolve, 1));
+    return 42;
+  };
+
+  // Assert that the cached path has statistically higher throughput
+  await expect(cachedLookup).toResolveWithHigherThroughputThan(uncachedLookup, {
+    duration: 500, warmup: 10,
+  });
+});
+
+// --- With error tolerance ---
+
+test('stable function has higher throughput than flaky function (tolerating 15% errors)', () => {
+  let flakyCount = 0;
+
+  // Function A: stable, small sort
+  const stableSort = () => {
+    const data = Array.from({length: 100}, () => Math.random());
+    data.sort((a, b) => a - b);
+  };
+
+  // Function B: flaky, larger sort that occasionally throws
+  const flakySort = () => {
+    flakyCount++;
+    if (flakyCount % 10 === 0) throw new Error('transient failure');
+    const data = Array.from({length: 500}, () => Math.random());
+    data.sort((a, b) => a - b);
+  };
+
+  // Assert while tolerating up to 15% errors from the flaky function
+  expect(stableSort).toHaveHigherThroughputThan(flakySort, {
+    duration: 500, allowedErrorRate: 0.15,
+  });
+});
+
+// --- With suite-level setup/teardown and per-op hooks ---
+
+test('throughput comparison with suite setup and per-op fresh state', () => {
+  // setup runs once before both measurement windows (not timed)
+  const setup = () => ({pool: 'shared-resource', items: 500});
+
+  // setupEach provides a fresh shuffled array for each operation (not timed)
+  const setupEach = (suite: unknown) => {
+    const {items} = suite as {items: number};
+    return Array.from({length: items}, () => Math.random());
+  };
+
+  // teardown runs once after both windows complete
+  const teardown = () => { /* release shared resource */ };
+
+  // Function A: single-pass max (O(n))
+  const linearMax = (_suite: unknown, data: unknown) => {
+    const arr = data as number[];
+    let max = -Infinity;
+    for (let i = 0; i < arr.length; i++) {
+      if (arr[i] > max) max = arr[i];
+    }
+    return max;
+  };
+
+  // Function B: sort-then-pick (O(n log n)) — genuinely more work
+  const sortMax = (_suite: unknown, data: unknown) => {
+    const arr = data as number[];
+    arr.sort((a, b) => a - b);
+    return arr[arr.length - 1];
+  };
+
+  // Assert throughput comparison with lifecycle hooks
+  expect(linearMax).toHaveHigherThroughputThan(sortMax, {
+    duration: 500, warmup: 20, setup, setupEach, teardown,
+  });
+});

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -216,7 +216,7 @@ export function generateComparisonInterpretation(
   return formatNotSignificantResult(tTest, absDiff, pctDiff, alpha);
 }
 
-function checkComparisonReliability(rmeA: Tag | null, rmeB: Tag | null): string | null {
+export function checkComparisonReliability(rmeA: Tag | null, rmeB: Tag | null): string | null {
   const unreliableA = rmeA !== null && rmeA.label === 'POOR';
   const unreliableB = rmeB !== null && rmeB.label === 'POOR';
   if (unreliableA || unreliableB) {
@@ -365,4 +365,51 @@ function interpretThroughputBelow(rme: Tag, cv: Tag, mad: Tag | null, pctBelow: 
     return `throughput is ${pctBelow.toFixed(1)}% below target; ops are genuinely inconsistent (CV: ${formatTag(cv)}) — investigate environment stability`;
   }
   return `throughput is consistently ${pctBelow.toFixed(1)}% below target with stable measurements (RME: ${formatTag(rme)}, CV: ${formatTag(cv)}) — the code is genuinely too slow`;
+}
+
+/**
+ * Generate a human-readable interpretation of a comparative throughput benchmark (A vs B).
+ *
+ * Mirrors `generateComparisonInterpretation` but frames the result in throughput
+ * (ops/sec) terms rather than duration terms.
+ */
+export function generateComparativeThroughputInterpretation(
+  statsA: Stats, statsB: Stats, tTest: WelchTTestResult, confidence: number,
+  actualOpsPerSecondA: number, actualOpsPerSecondB: number,
+): string {
+  const rmeA = classifyRME(statsA.relativeMarginOfError);
+  const rmeB = classifyRME(statsB.relativeMarginOfError);
+
+  const reliabilityCheck = checkComparisonReliability(rmeA, rmeB);
+  if (reliabilityCheck !== null) return reliabilityCheck;
+
+  const alpha = 1 - confidence;
+  const opsDiff = Math.abs(actualOpsPerSecondA - actualOpsPerSecondB);
+  /* istanbul ignore next -- defensive guard: actualOpsPerSecondB=0 requires empty durationsB, which is caught upstream */
+  const pctDiff = actualOpsPerSecondB === 0 ? 0 : (opsDiff / actualOpsPerSecondB) * 100;
+
+  if (tTest.pValue < alpha) {
+    return formatSignificantThroughputResult(tTest, actualOpsPerSecondA, actualOpsPerSecondB, opsDiff, pctDiff, alpha);
+  }
+  return formatNotSignificantThroughputResult(tTest, actualOpsPerSecondA, actualOpsPerSecondB, opsDiff, pctDiff, alpha);
+}
+
+function formatSignificantThroughputResult(tTest: WelchTTestResult, opsA: number, opsB: number, opsDiff: number, pctDiff: number, alpha: number): string {
+  let practical = '';
+  if (pctDiff < 1) {
+    practical = '. However, the difference is less than 1% — statistically significant but may be practically negligible';
+  } else if (pctDiff < 5) {
+    practical = '. The difference is modest (< 5%) — consider whether this is practically meaningful for your use case';
+  }
+  return `Function A has statistically significantly higher throughput than Function B (${Math.round(opsA)} vs ${Math.round(opsB)} ops/sec, p=${formatPValue(tTest.pValue)} < α=${alpha.toFixed(2)}), a difference of ${Math.round(opsDiff)} ops/sec (${pctDiff.toFixed(1)}%)${practical}`;
+}
+
+function formatNotSignificantThroughputResult(tTest: WelchTTestResult, opsA: number, opsB: number, opsDiff: number, pctDiff: number, alpha: number): string {
+  if (tTest.meanDifference < 0) {
+    return `no statistically significant evidence that Function A has higher throughput than Function B (${Math.round(opsA)} vs ${Math.round(opsB)} ops/sec, p=${formatPValue(tTest.pValue)} >= α=${alpha.toFixed(2)}). Function A trends higher by ${Math.round(opsDiff)} ops/sec (${pctDiff.toFixed(1)}%) but the difference could be due to chance — increase duration for more statistical power`;
+  }
+  if (tTest.meanDifference === 0) {
+    return `no statistically significant difference — both functions have identical throughput (p=${formatPValue(tTest.pValue)} >= α=${alpha.toFixed(2)})`;
+  }
+  return `Function A appears to have lower throughput than Function B by ${Math.round(opsDiff)} ops/sec (${pctDiff.toFixed(1)}%), not higher (p=${formatPValue(tTest.pValue)} >= α=${alpha.toFixed(2)})`;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -9,9 +9,11 @@ import {
   generateInterpretation,
   generateComparisonInterpretation,
   generateThroughputInterpretation,
+  generateComparativeThroughputInterpretation,
   hasWarningConditions,
   formatTag,
   formatPValue,
+  Tag,
 } from "./diagnostics";
 import {formatMs} from "./format";
 export {formatMs} from "./format";
@@ -42,19 +44,86 @@ export function formatStatValue(value: number | null): string {
   return value === null ? 'N/A' : formatMs(value);
 }
 
+/** Append the shared error-rate line and warnings list to a stats block's lines array. */
+function appendErrorInfoAndWarnings(lines: string[], warnings: string[], errorInfo?: ErrorInfo): void {
+  if (errorInfo !== undefined && errorInfo.errorCount > 0) {
+    const actualRate = (errorInfo.errorCount / errorInfo.totalIterations * 100).toFixed(1);
+    const allowedRate = (errorInfo.allowedRate * 100).toFixed(1);
+    lines.push(`Error rate: ${errorInfo.errorCount}/${errorInfo.totalIterations} (${actualRate}%) [within ${allowedRate}% tolerance]`);
+  }
+
+  if (warnings.length > 0) {
+    lines.push('Warnings:');
+    for (const warning of warnings) {
+      lines.push(`  - ${warning}`);
+    }
+  }
+}
+
+/** Format the CI value (without prefix). Returns 'N/A (insufficient data)' or '[lower, upper]ms'. */
+function formatCIValue(ci: [number, number] | null): string {
+  if (ci === null) return 'N/A (insufficient data)';
+  return `[${formatMs(ci[0])}, ${formatMs(ci[1])}]ms`;
+}
+
+/** Format the RME value (without prefix). Returns 'N/A' or 'X.XX% [TAG]'. */
+function formatRMEValue(rme: number | null, tag: Tag | null): string {
+  if (rme === null || tag === null) return 'N/A';
+  return `${rme.toFixed(2)}% [${formatTag(tag)}]`;
+}
+
+/** Format the CV value (without prefix). Returns 'N/A' or 'X.XX [TAG]'. */
+function formatCVValue(cv: number | null, tag: Tag | null): string {
+  if (cv === null || tag === null) return 'N/A';
+  return `${cv.toFixed(2)} [${formatTag(tag)}]`;
+}
+
+type EffectiveDurationsResult =
+  | { ok: true; effective: number[] }
+  | { ok: false; message: string };
+
+/** Apply outlier removal and verify minimum sample size (n >= 2) for one function in a comparative matcher. */
+function prepareEffectiveDurations(
+  durations: number[], removeOutliersEnabled: boolean, fnLabel: 'Function A' | 'Function B', noun: 'iterations' | 'operations',
+): EffectiveDurationsResult {
+  const effective = removeOutliersEnabled ? removeOutliers(durations) : durations;
+  /* istanbul ignore next -- defensive guard: Tukey's fences cannot remove all points from a homogeneous dataset */
+  if (effective.length === 0) {
+    return {ok: false, message: `${fnLabel}: all ${durations.length} successful ${noun} were removed as outliers`};
+  }
+  if (effective.length < 2) {
+    return {ok: false, message: `${fnLabel}: insufficient data after processing (n=${effective.length}); Welch's t-test requires at least 2 data points per function`};
+  }
+  return {ok: true, effective};
+}
+
+/** Build the pass/fail result with formatted message for both comparative matcher families. */
+function buildComparativeResult(
+  pass: boolean, alpha: number, pValue: number, statsBlock: string,
+  passHeadline: string, failHeadline: string,
+): { pass: boolean; message: () => string } {
+  const formattedP = formatPValue(pValue);
+  if (pass) {
+    return {
+      pass: true,
+      message: () => `${passHeadline} (p=${formattedP} < α=${alpha.toFixed(2)})\n\n${statsBlock}`,
+    };
+  }
+  return {
+    pass: false,
+    message: () => `${failHeadline} (p=${formattedP} >= α=${alpha.toFixed(2)})\n\n${statsBlock}`,
+  };
+}
+
 export function formatStatsBlock(stats: Stats, durations: number[], expectedDuration?: number, setupTeardownActive?: boolean, errorInfo?: ErrorInfo): string {
   const rmeTag = classifyRME(stats.relativeMarginOfError);
   const cvTag = classifyCV(stats.coefficientOfVariation);
 
   const ciText = stats.confidenceInterval === null
     ? 'Confidence Interval (CI): N/A (insufficient data)'
-    : `Confidence Interval (CI): 95% [${formatMs(stats.confidenceInterval[0])}, ${formatMs(stats.confidenceInterval[1])}]ms`;
-  const rmeText = stats.relativeMarginOfError === null || rmeTag === null
-    ? 'Relative Margin of Error (RME): N/A'
-    : `Relative Margin of Error (RME): ${stats.relativeMarginOfError.toFixed(2)}% [${formatTag(rmeTag)}]`;
-  const cvText = stats.coefficientOfVariation === null || cvTag === null
-    ? 'Coefficient of Variation (CV): N/A'
-    : `Coefficient of Variation (CV): ${stats.coefficientOfVariation.toFixed(2)} [${formatTag(cvTag)}]`;
+    : `Confidence Interval (CI): 95% ${formatCIValue(stats.confidenceInterval)}`;
+  const rmeText = `Relative Margin of Error (RME): ${formatRMEValue(stats.relativeMarginOfError, rmeTag)}`;
+  const cvText = `Coefficient of Variation (CV): ${formatCVValue(stats.coefficientOfVariation, cvTag)}`;
 
   const p25 = calcQuantile(25, durations);
   const p50 = stats.median;
@@ -85,18 +154,7 @@ export function formatStatsBlock(stats: Stats, durations: number[], expectedDura
     `Interpretation: ${generateInterpretation(stats, expectedDuration, errorInfo)}`,
   ];
 
-  if (errorInfo !== undefined && errorInfo.errorCount > 0) {
-    const actualRate = (errorInfo.errorCount / errorInfo.totalIterations * 100).toFixed(1);
-    const allowedRate = (errorInfo.allowedRate * 100).toFixed(1);
-    lines.push(`Error rate: ${errorInfo.errorCount}/${errorInfo.totalIterations} (${actualRate}%) [within ${allowedRate}% tolerance]`);
-  }
-
-  if (stats.warnings.length > 0) {
-    lines.push('Warnings:');
-    for (const warning of stats.warnings) {
-      lines.push(`  - ${warning}`);
-    }
-  }
+  appendErrorInfoAndWarnings(lines, stats.warnings, errorInfo);
 
   return lines.join('\n');
 }
@@ -255,28 +313,14 @@ export function processComparativeResults(opts: ComparativeResultsOptions): { me
     return {pass: false, message: () => `Function B: error rate ${errorCountB}/${count} (${(errorRateB * 100).toFixed(1)}%) exceeds allowed ${(allowedErrorRate * 100).toFixed(1)}%`};
   }
 
-  // Remove outliers if enabled
-  const effectiveA = removeOutliersEnabled ? removeOutliers(durationsA) : durationsA;
-  /* istanbul ignore next -- defensive guard: Tukey's fences cannot remove all points from a homogeneous dataset */
-  if (effectiveA.length === 0) {
-    return {pass: false, message: () => `Function A: all ${durationsA.length} successful iterations were removed as outliers`};
-  }
-  const effectiveB = removeOutliersEnabled ? removeOutliers(durationsB) : durationsB;
-  /* istanbul ignore next -- defensive guard: Tukey's fences cannot remove all points from a homogeneous dataset */
-  if (effectiveB.length === 0) {
-    return {pass: false, message: () => `Function B: all ${durationsB.length} successful iterations were removed as outliers`};
-  }
+  // Remove outliers if enabled and verify minimum sample size for t-test
+  const checkA = prepareEffectiveDurations(durationsA, removeOutliersEnabled, 'Function A', 'iterations');
+  if (!checkA.ok) return {pass: false, message: () => checkA.message};
+  const checkB = prepareEffectiveDurations(durationsB, removeOutliersEnabled, 'Function B', 'iterations');
+  if (!checkB.ok) return {pass: false, message: () => checkB.message};
 
-  // Check minimum sample size for t-test
-  if (effectiveA.length < 2) {
-    return {pass: false, message: () => `Function A: insufficient data after processing (n=${effectiveA.length}); Welch's t-test requires at least 2 data points per function`};
-  }
-  if (effectiveB.length < 2) {
-    return {pass: false, message: () => `Function B: insufficient data after processing (n=${effectiveB.length}); Welch's t-test requires at least 2 data points per function`};
-  }
-
-  const statsA = calcStats(effectiveA);
-  const statsB = calcStats(effectiveB);
+  const statsA = calcStats(checkA.effective);
+  const statsB = calcStats(checkB.effective);
   const tTest = welchTTest(statsA, statsB, confidence);
   const alpha = 1 - confidence;
   const pass = tTest.pValue < alpha;
@@ -284,21 +328,16 @@ export function processComparativeResults(opts: ComparativeResultsOptions): { me
   const errorInfoA: ErrorInfo | undefined = errorCountA > 0 ? {errorCount: errorCountA, totalIterations: count, allowedRate: allowedErrorRate} : undefined;
   const errorInfoB: ErrorInfo | undefined = errorCountB > 0 ? {errorCount: errorCountB, totalIterations: count, allowedRate: allowedErrorRate} : undefined;
 
-  const statsBlock = formatComparativeStatsBlock({statsA, statsB, durationsA: effectiveA, durationsB: effectiveB, tTest, confidence, setupTeardownActive, errorInfoA, errorInfoB});
+  const statsBlock = formatComparativeStatsBlock({statsA, statsB, durationsA: checkA.effective, durationsB: checkB.effective, tTest, confidence, setupTeardownActive, errorInfoA, errorInfoB});
 
   const warnings = hasWarningConditions(statsA, undefined, errorInfoA) || hasWarningConditions(statsB, undefined, errorInfoB);
   logDiagnosticsIfNeeded(pass, statsBlock, opts.logDiagnostics, warnings);
 
-  if (pass) {
-    return {
-      pass: true,
-      message: () => `expected Function A NOT to be faster than Function B,\nbut A is statistically significantly faster (p=${tTest.pValue < 0.0001 ? '<0.0001' : tTest.pValue.toFixed(4)} < α=${alpha.toFixed(2)})\n\n${statsBlock}`,
-    };
-  }
-  return {
-    pass: false,
-    message: () => `expected Function A to be faster than Function B,\nbut no statistically significant difference was found (p=${tTest.pValue.toFixed(4)} >= α=${alpha.toFixed(2)})\n\n${statsBlock}`,
-  };
+  return buildComparativeResult(
+    pass, alpha, tTest.pValue, statsBlock,
+    'expected Function A NOT to be faster than Function B,\nbut A is statistically significantly faster',
+    'expected Function A to be faster than Function B,\nbut no statistically significant difference was found',
+  );
 }
 
 export interface ThroughputResultsOptions {
@@ -375,7 +414,7 @@ interface ThroughputStatsBlockOptions {
   errorInfo?: ErrorInfo;
 }
 
-function formatThroughputCI(confidenceInterval: [number, number] | null): string {
+export function formatThroughputCI(confidenceInterval: [number, number] | null): string {
   if (confidenceInterval === null) {
     return '  CI 95%: N/A (insufficient data)';
   }
@@ -396,20 +435,14 @@ function formatTargetComparison(actualOpsPerSecond: number, expectedOpsPerSecond
   return `  Target: ${Math.round(expectedOpsPerSecond)} ops/sec — ${label} of ${Math.round(absDiff)} ops/sec (${pctDiff.toFixed(1)}%)`;
 }
 
-function formatPerOpTimingSection(stats: Stats, durations: number[], setupTeardownActive: boolean): string[] {
+export function formatPerOpTimingSection(stats: Stats, durations: number[], setupTeardownActive: boolean): string[] {
   const rmeTag = classifyRME(stats.relativeMarginOfError);
   const cvTag = classifyCV(stats.coefficientOfVariation);
   const madTag = classifyMAD(stats.mad, stats.median);
 
-  const ciText = stats.confidenceInterval === null
-    ? 'N/A (insufficient data)'
-    : `[${formatMs(stats.confidenceInterval[0])}, ${formatMs(stats.confidenceInterval[1])}]ms`;
-  const rmeText = stats.relativeMarginOfError === null || rmeTag === null
-    ? 'N/A'
-    : `${stats.relativeMarginOfError.toFixed(2)}% [${formatTag(rmeTag)}]`;
-  const cvText = stats.coefficientOfVariation === null || cvTag === null
-    ? 'N/A'
-    : `${stats.coefficientOfVariation.toFixed(2)} [${formatTag(cvTag)}]`;
+  const ciText = formatCIValue(stats.confidenceInterval);
+  const rmeText = formatRMEValue(stats.relativeMarginOfError, rmeTag);
+  const cvText = formatCVValue(stats.coefficientOfVariation, cvTag);
 
   const p25 = calcQuantile(25, durations);
   const p50 = stats.median;
@@ -451,18 +484,138 @@ function formatThroughputStatsBlock(opts: ThroughputStatsBlockOptions): string {
     `Interpretation: ${interpretation}`,
   ];
 
-  if (errorInfo !== undefined && errorInfo.errorCount > 0) {
-    const actualRate = (errorInfo.errorCount / errorInfo.totalIterations * 100).toFixed(1);
-    const allowedRate = (errorInfo.allowedRate * 100).toFixed(1);
-    lines.push(`Error rate: ${errorInfo.errorCount}/${errorInfo.totalIterations} (${actualRate}%) [within ${allowedRate}% tolerance]`);
-  }
-
-  if (stats.warnings.length > 0) {
-    lines.push('Warnings:');
-    for (const warning of stats.warnings) {
-      lines.push(`  - ${warning}`);
-    }
-  }
+  appendErrorInfoAndWarnings(lines, stats.warnings, errorInfo);
 
   return lines.join('\n');
+}
+
+function formatThroughputFunctionBlock(
+  stats: Stats, durations: number[], actualOpsPerSecond: number, totalOps: number, duration: number,
+  setupTeardownActive: boolean, errorInfo?: ErrorInfo,
+): string {
+  const lines = [
+    `Throughput: ${Math.round(actualOpsPerSecond)} ops/sec over ${Math.round(duration)}ms (${totalOps} total operations)`,
+    formatThroughputCI(stats.confidenceInterval),
+    '',
+    ...formatPerOpTimingSection(stats, durations, setupTeardownActive),
+  ];
+
+  appendErrorInfoAndWarnings(lines, stats.warnings, errorInfo);
+
+  return lines.join('\n');
+}
+
+function formatThroughputComparisonLine(actualOpsPerSecondA: number, actualOpsPerSecondB: number): string {
+  const opsDiff = Math.abs(actualOpsPerSecondA - actualOpsPerSecondB);
+  let direction: string;
+  if (actualOpsPerSecondA === actualOpsPerSecondB) {
+    direction = '(identical throughput)';
+  } else if (actualOpsPerSecondA > actualOpsPerSecondB) {
+    direction = `Function A is higher by ${Math.round(opsDiff)} ops/sec`;
+  } else {
+    direction = `Function A is lower by ${Math.round(opsDiff)} ops/sec`;
+  }
+  return `Throughput: A=${Math.round(actualOpsPerSecondA)} ops/sec, B=${Math.round(actualOpsPerSecondB)} ops/sec — ${direction}`;
+}
+
+export interface ComparativeThroughputStatsBlockOptions {
+  statsA: Stats; statsB: Stats;
+  durationsA: number[]; durationsB: number[];
+  actualOpsPerSecondA: number; actualOpsPerSecondB: number;
+  totalOpsA: number; totalOpsB: number;
+  duration: number;
+  tTest: WelchTTestResult; confidence: number;
+  setupTeardownActive: boolean;
+  errorInfoA?: ErrorInfo; errorInfoB?: ErrorInfo;
+}
+
+export function formatComparativeThroughputStatsBlock(opts: ComparativeThroughputStatsBlockOptions): string {
+  const {statsA, statsB, durationsA, durationsB, actualOpsPerSecondA, actualOpsPerSecondB, totalOpsA, totalOpsB, duration, tTest, confidence, setupTeardownActive, errorInfoA, errorInfoB} = opts;
+  const blockA = formatThroughputFunctionBlock(statsA, durationsA, actualOpsPerSecondA, totalOpsA, duration, setupTeardownActive, errorInfoA);
+  const blockB = formatThroughputFunctionBlock(statsB, durationsB, actualOpsPerSecondB, totalOpsB, duration, setupTeardownActive, errorInfoB);
+
+  const lines = [
+    '--- Function A ---',
+    blockA,
+    '',
+    '--- Function B ---',
+    blockB,
+    '',
+    '--- Comparison ---',
+    formatThroughputComparisonLine(actualOpsPerSecondA, actualOpsPerSecondB),
+    `Welch's t-test: t=${formatTStatistic(tTest.t)}, df=${tTest.df.toFixed(1)}, p=${formatPValue(tTest.pValue)} (one-sided)`,
+    `Confidence interval for per-op difference: ${(confidence * 100).toFixed(0)}% [${formatMs(tTest.confidenceInterval[0])}, ${formatMs(tTest.confidenceInterval[1])}]ms`,
+    `Result: ${generateComparativeThroughputInterpretation(statsA, statsB, tTest, confidence, actualOpsPerSecondA, actualOpsPerSecondB)}`,
+  ];
+
+  return lines.join('\n');
+}
+
+export interface ComparativeThroughputResultsOptions {
+  durationsA: number[]; durationsB: number[];
+  totalOpsA: number; totalOpsB: number;
+  errorCountA: number; errorCountB: number;
+  allowedErrorRate: number; confidence: number;
+  duration: number;
+  setupTeardownActive: boolean; removeOutliersEnabled: boolean;
+  logDiagnostics: LogDiagnostics;
+}
+
+export function processComparativeThroughputResults(opts: ComparativeThroughputResultsOptions): { message: () => string; pass: boolean } {
+  const {durationsA, durationsB, totalOpsA, totalOpsB, errorCountA, errorCountB, allowedErrorRate, confidence, duration, setupTeardownActive, removeOutliersEnabled} = opts;
+
+  // Check all-failed per function
+  if (durationsA.length === 0) {
+    return {pass: false, message: () => `Function A: all ${totalOpsA} operations failed during ${Math.round(duration)}ms window (100% error rate, allowed ${(allowedErrorRate * 100).toFixed(1)}%)`};
+  }
+  if (durationsB.length === 0) {
+    return {pass: false, message: () => `Function B: all ${totalOpsB} operations failed during ${Math.round(duration)}ms window (100% error rate, allowed ${(allowedErrorRate * 100).toFixed(1)}%)`};
+  }
+
+  // Check error rate per function (pre-outlier-removal counts)
+  /* istanbul ignore next -- defensive guard: totalOps is always > 0 when durations is non-empty */
+  const errorRateA = totalOpsA > 0 ? errorCountA / totalOpsA : 0;
+  if (errorRateA > allowedErrorRate) {
+    return {pass: false, message: () => `Function A: error rate ${errorCountA}/${totalOpsA} (${(errorRateA * 100).toFixed(1)}%) exceeds allowed ${(allowedErrorRate * 100).toFixed(1)}%`};
+  }
+  /* istanbul ignore next -- defensive guard: totalOps is always > 0 when durations is non-empty */
+  const errorRateB = totalOpsB > 0 ? errorCountB / totalOpsB : 0;
+  if (errorRateB > allowedErrorRate) {
+    return {pass: false, message: () => `Function B: error rate ${errorCountB}/${totalOpsB} (${(errorRateB * 100).toFixed(1)}%) exceeds allowed ${(allowedErrorRate * 100).toFixed(1)}%`};
+  }
+
+  // Remove outliers if enabled and verify minimum sample size for t-test
+  const checkA = prepareEffectiveDurations(durationsA, removeOutliersEnabled, 'Function A', 'operations');
+  if (!checkA.ok) return {pass: false, message: () => checkA.message};
+  const checkB = prepareEffectiveDurations(durationsB, removeOutliersEnabled, 'Function B', 'operations');
+  if (!checkB.ok) return {pass: false, message: () => checkB.message};
+
+  const statsA = calcStats(checkA.effective);
+  const statsB = calcStats(checkB.effective);
+  const tTest = welchTTest(statsA, statsB, confidence);
+  const alpha = 1 - confidence;
+  const pass = tTest.pValue < alpha;
+
+  // Use pre-outlier-removal counts for throughput (outlier removal cleans per-op stats, not ops completed)
+  const actualOpsPerSecondA = (durationsA.length / duration) * 1000;
+  const actualOpsPerSecondB = (durationsB.length / duration) * 1000;
+
+  const errorInfoA: ErrorInfo | undefined = errorCountA > 0 ? {errorCount: errorCountA, totalIterations: totalOpsA, allowedRate: allowedErrorRate} : undefined;
+  const errorInfoB: ErrorInfo | undefined = errorCountB > 0 ? {errorCount: errorCountB, totalIterations: totalOpsB, allowedRate: allowedErrorRate} : undefined;
+
+  const statsBlock = formatComparativeThroughputStatsBlock({
+    statsA, statsB, durationsA: checkA.effective, durationsB: checkB.effective,
+    actualOpsPerSecondA, actualOpsPerSecondB,
+    totalOpsA: durationsA.length, totalOpsB: durationsB.length,
+    duration, tTest, confidence, setupTeardownActive, errorInfoA, errorInfoB,
+  });
+
+  const warnings = hasWarningConditions(statsA, undefined, errorInfoA) || hasWarningConditions(statsB, undefined, errorInfoB);
+  logDiagnosticsIfNeeded(pass, statsBlock, opts.logDiagnostics, warnings);
+
+  return buildComparativeResult(
+    pass, alpha, tTest.pValue, statsBlock,
+    'expected Function A NOT to have higher throughput than Function B,\nbut A has statistically significantly higher throughput',
+    'expected Function A to have higher throughput than Function B,\nbut no statistically significant difference was found',
+  );
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -84,3 +84,17 @@ export async function warmupAsync(callback: AsyncCallback, warmupCount: number, 
     await runAsyncWithHooks(callback, suiteState, hooks);
   }
 }
+
+export function warmupSyncInterleaved(callbackA: SyncCallback, callbackB: SyncCallback, warmupCount: number, suiteState: unknown, hooks: SyncHooks): void {
+  for (let i = 0; i < warmupCount; i++) {
+    runSyncWithHooks(callbackA, suiteState, hooks);
+    runSyncWithHooks(callbackB, suiteState, hooks);
+  }
+}
+
+export async function warmupAsyncInterleaved(callbackA: AsyncCallback, callbackB: AsyncCallback, warmupCount: number, suiteState: unknown, hooks: AsyncHooks): Promise<void> {
+  for (let i = 0; i < warmupCount; i++) {
+    await runAsyncWithHooks(callbackA, suiteState, hooks);
+    await runAsyncWithHooks(callbackB, suiteState, hooks);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import {toCompleteWithin, toResolveWithin} from './matchers-single';
 import {toCompleteWithinQuantile, toResolveWithinQuantile} from './matchers-quantile';
 import {toBeFasterThan, toResolveFasterThan} from './matchers-comparative';
 import {toAchieveOpsPerSecond, toResolveAtOpsPerSecond} from './matchers-throughput';
+import {toHaveHigherThroughputThan, toResolveWithHigherThroughputThan} from './matchers-comparative-throughput';
 
 expect.extend({
   toCompleteWithin,
@@ -13,6 +14,8 @@ expect.extend({
   toResolveFasterThan,
   toAchieveOpsPerSecond,
   toResolveAtOpsPerSecond,
+  toHaveHigherThroughputThan,
+  toResolveWithHigherThroughputThan,
 });
 
 declare global {
@@ -95,6 +98,32 @@ declare global {
       toResolveAtOpsPerSecond<T = void, U = void>(expectedOpsPerSecond: number, options: {
         duration: number,
         warmup?: number,
+        outliers?: 'remove' | 'keep',
+        setup?: () => T | Promise<T>,
+        teardown?: (suiteState: T) => void | Promise<void>,
+        setupEach?: (suiteState: T) => U | Promise<U>,
+        teardownEach?: (suiteState: T, iterState: U) => void | Promise<void>,
+        allowedErrorRate?: number,
+        logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
+      }): Promise<R>;
+
+      toHaveHigherThroughputThan<T = void, U = void>(comparisonFn: (...args: unknown[]) => unknown, options: {
+        duration: number,
+        warmup?: number,
+        confidence?: number,
+        outliers?: 'remove' | 'keep',
+        setup?: () => T,
+        teardown?: (suiteState: T) => void,
+        setupEach?: (suiteState: T) => U,
+        teardownEach?: (suiteState: T, iterState: U) => void,
+        allowedErrorRate?: number,
+        logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
+      }): R;
+
+      toResolveWithHigherThroughputThan<T = void, U = void>(comparisonFn: (...args: unknown[]) => Promise<unknown>, options: {
+        duration: number,
+        warmup?: number,
+        confidence?: number,
         outliers?: 'remove' | 'keep',
         setup?: () => T | Promise<T>,
         teardown?: (suiteState: T) => void | Promise<void>,

--- a/src/matchers-comparative-throughput.ts
+++ b/src/matchers-comparative-throughput.ts
@@ -1,0 +1,111 @@
+import {validateCallback, validateComparativeThroughputOptions} from "./validators";
+import {processComparativeThroughputResults, LogDiagnostics, ComparativeThroughputResultsOptions} from "./helpers";
+import {SyncHooks, AsyncHooks, SyncCallback, AsyncCallback, warmupSyncInterleaved, warmupAsyncInterleaved} from "./hooks";
+import {measureSyncThroughput, measureAsyncThroughput} from "./matchers-throughput";
+
+interface MeasurementResult {
+  durations: number[];
+  errorCount: number;
+}
+
+/** Build the options object passed to processComparativeThroughputResults from per-function measurement results. */
+function buildResultsOptions(
+  resultA: MeasurementResult,
+  resultB: MeasurementResult,
+  options: { duration: number; outliers?: 'remove' | 'keep' },
+  hooks: SyncHooks | AsyncHooks,
+  allowedErrorRate: number,
+  confidence: number,
+  logDiagnostics: LogDiagnostics,
+): ComparativeThroughputResultsOptions {
+  return {
+    durationsA: resultA.durations, durationsB: resultB.durations,
+    totalOpsA: resultA.durations.length + resultA.errorCount,
+    totalOpsB: resultB.durations.length + resultB.errorCount,
+    errorCountA: resultA.errorCount, errorCountB: resultB.errorCount,
+    allowedErrorRate, confidence, duration: options.duration,
+    setupTeardownActive: !!(hooks.setup || hooks.teardown || hooks.setupEach || hooks.teardownEach),
+    removeOutliersEnabled: options.outliers === 'remove',
+    logDiagnostics,
+  };
+}
+
+/**
+ * Assert that synchronous function A has statistically higher throughput than function B
+ * using time-bounded measurement windows and Welch's t-test on per-op durations.
+ */
+export function toHaveHigherThroughputThan(callbackA: SyncCallback, callbackB: SyncCallback, options: {
+  duration: number,
+  warmup?: number,
+  confidence?: number,
+  outliers?: 'remove' | 'keep',
+  setup?: () => unknown,
+  teardown?: (suiteState: unknown) => void,
+  setupEach?: (suiteState: unknown) => unknown,
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void,
+  allowedErrorRate?: number,
+  logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
+}) {
+  validateCallback(callbackA);
+  validateCallback(callbackB);
+  validateComparativeThroughputOptions(options);
+
+  const confidence = options.confidence ?? 0.95;
+  const hooks: SyncHooks = options;
+  const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const logDiagnostics = options.logDiagnostics ?? 'WARN';
+  const suiteState = hooks.setup ? hooks.setup() : undefined;
+
+  try {
+    warmupSyncInterleaved(callbackA, callbackB, options.warmup ?? 0, suiteState, hooks);
+
+    const resultA = measureSyncThroughput(callbackA, options.duration, suiteState, hooks, allowedErrorRate);
+    const resultB = measureSyncThroughput(callbackB, options.duration, suiteState, hooks, allowedErrorRate);
+
+    return processComparativeThroughputResults(
+      buildResultsOptions(resultA, resultB, options, hooks, allowedErrorRate, confidence, logDiagnostics),
+    );
+  } finally {
+    if (hooks.teardown) hooks.teardown(suiteState);
+  }
+}
+
+/**
+ * Assert that asynchronous function A has statistically higher throughput than function B
+ * using time-bounded measurement windows and Welch's t-test on per-op durations.
+ */
+export async function toResolveWithHigherThroughputThan(promiseA: AsyncCallback, promiseB: AsyncCallback, options: {
+  duration: number,
+  warmup?: number,
+  confidence?: number,
+  outliers?: 'remove' | 'keep',
+  setup?: () => unknown,
+  teardown?: (suiteState: unknown) => void | Promise<void>,
+  setupEach?: (suiteState: unknown) => unknown,
+  teardownEach?: (suiteState: unknown, iterState: unknown) => void | Promise<void>,
+  allowedErrorRate?: number,
+  logDiagnostics?: 'INFO' | 'WARN' | 'FAIL',
+}) {
+  validateCallback(promiseA);
+  validateCallback(promiseB);
+  validateComparativeThroughputOptions(options);
+
+  const confidence = options.confidence ?? 0.95;
+  const hooks: AsyncHooks = options;
+  const allowedErrorRate = options.allowedErrorRate ?? 0;
+  const logDiagnostics = options.logDiagnostics ?? 'WARN';
+  const suiteState = hooks.setup ? await hooks.setup() : undefined;
+
+  try {
+    await warmupAsyncInterleaved(promiseA, promiseB, options.warmup ?? 0, suiteState, hooks);
+
+    const resultA = await measureAsyncThroughput(promiseA, options.duration, suiteState, hooks, allowedErrorRate);
+    const resultB = await measureAsyncThroughput(promiseB, options.duration, suiteState, hooks, allowedErrorRate);
+
+    return processComparativeThroughputResults(
+      buildResultsOptions(resultA, resultB, options, hooks, allowedErrorRate, confidence, logDiagnostics),
+    );
+  } finally {
+    if (hooks.teardown) await hooks.teardown(suiteState);
+  }
+}

--- a/src/matchers-comparative.ts
+++ b/src/matchers-comparative.ts
@@ -1,13 +1,6 @@
 import {validateCallback, validateComparativeOptions} from "./validators";
 import {processComparativeResults} from "./helpers";
-import {SyncHooks, AsyncHooks, SyncCallback, AsyncCallback, runSyncWithHooks, runAsyncWithHooks, measureSync, measureAsync} from "./hooks";
-
-function warmupSync(callbackA: SyncCallback, callbackB: SyncCallback, warmupCount: number, suiteState: unknown, hooks: SyncHooks): void {
-  for (let i = 0; i < warmupCount; i++) {
-    runSyncWithHooks(callbackA, suiteState, hooks);
-    runSyncWithHooks(callbackB, suiteState, hooks);
-  }
-}
+import {SyncHooks, AsyncHooks, SyncCallback, AsyncCallback, measureSync, measureAsync, warmupSyncInterleaved, warmupAsyncInterleaved} from "./hooks";
 
 /**
  * Assert that synchronous function A is statistically faster than function B
@@ -37,7 +30,7 @@ export function toBeFasterThan(callbackA: SyncCallback, callbackB: SyncCallback,
   const suiteState = hooks.setup ? hooks.setup() : undefined;
 
   try {
-    warmupSync(callbackA, callbackB, options.warmup ?? 0, suiteState, hooks);
+    warmupSyncInterleaved(callbackA, callbackB, options.warmup ?? 0, suiteState, hooks);
 
     const durationsA: number[] = [];
     const durationsB: number[] = [];
@@ -58,13 +51,6 @@ export function toBeFasterThan(callbackA: SyncCallback, callbackB: SyncCallback,
     });
   } finally {
     if (hooks.teardown) hooks.teardown(suiteState);
-  }
-}
-
-async function warmupAsync(callbackA: AsyncCallback, callbackB: AsyncCallback, warmupCount: number, suiteState: unknown, hooks: AsyncHooks): Promise<void> {
-  for (let i = 0; i < warmupCount; i++) {
-    await runAsyncWithHooks(callbackA, suiteState, hooks);
-    await runAsyncWithHooks(callbackB, suiteState, hooks);
   }
 }
 
@@ -96,7 +82,7 @@ export async function toResolveFasterThan(promiseA: AsyncCallback, promiseB: Asy
   const suiteState = hooks.setup ? await hooks.setup() : undefined;
 
   try {
-    await warmupAsync(promiseA, promiseB, options.warmup ?? 0, suiteState, hooks);
+    await warmupAsyncInterleaved(promiseA, promiseB, options.warmup ?? 0, suiteState, hooks);
 
     const durationsA: number[] = [];
     const durationsB: number[] = [];

--- a/src/matchers-throughput.ts
+++ b/src/matchers-throughput.ts
@@ -3,7 +3,7 @@ import {validateCallback, validateExpectedOpsPerSecond, validateThroughputOption
 import {processThroughputResults} from "./helpers";
 import {SyncHooks, AsyncHooks, SyncCallback, AsyncCallback, warmupSync, warmupAsync} from "./hooks";
 
-function measureSyncThroughput(
+export function measureSyncThroughput(
   callback: SyncCallback, duration: number, suiteState: unknown,
   hooks: SyncHooks, allowedErrorRate: number,
 ): { durations: number[]; errorCount: number } {
@@ -71,7 +71,7 @@ export function toAchieveOpsPerSecond(callback: SyncCallback, expectedOpsPerSeco
   }
 }
 
-async function measureAsyncThroughput(
+export async function measureAsyncThroughput(
   callback: AsyncCallback, duration: number, suiteState: unknown,
   hooks: AsyncHooks, allowedErrorRate: number,
 ): Promise<{ durations: number[]; errorCount: number }> {

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -4,6 +4,50 @@ function validateLogDiagnostics(logDiagnostics: string | undefined): void {
   }
 }
 
+function validateWarmup(warmup: number | undefined): void {
+  if (warmup !== undefined && (!Number.isInteger(warmup) || warmup < 0)) {
+    throw new Error(`jest-performance-matchers: warmup must be a non-negative integer, received ${warmup}`);
+  }
+}
+
+function validateConfidence(confidence: number | undefined): void {
+  if (confidence === undefined) return;
+  if (typeof confidence !== 'number' || !Number.isFinite(confidence) || confidence <= 0 || confidence >= 1) {
+    throw new Error(`jest-performance-matchers: confidence must be a number between 0 (exclusive) and 1 (exclusive), received ${confidence}`);
+  }
+}
+
+function validateOutliers(outliers: string | undefined): void {
+  if (outliers !== undefined && outliers !== 'remove' && outliers !== 'keep') {
+    throw new Error(`jest-performance-matchers: outliers must be 'remove' or 'keep', received '${outliers}'`);
+  }
+}
+
+function validateAllowedErrorRate(allowedErrorRate: number | undefined): void {
+  if (allowedErrorRate === undefined) return;
+  if (typeof allowedErrorRate !== 'number' || !Number.isFinite(allowedErrorRate) || allowedErrorRate < 0 || allowedErrorRate > 1) {
+    throw new Error(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${allowedErrorRate}`);
+  }
+}
+
+interface CommonTailOptions {
+  outliers?: 'remove' | 'keep' | string;
+  allowedErrorRate?: number;
+  logDiagnostics?: string;
+  setup?: unknown;
+  teardown?: unknown;
+  setupEach?: unknown;
+  teardownEach?: unknown;
+}
+
+/** Shared validation tail used by every multi-iteration matcher's options. */
+function validateCommonTail(options: CommonTailOptions): void {
+  validateOutliers(options.outliers);
+  validateAllowedErrorRate(options.allowedErrorRate);
+  validateLogDiagnostics(options.logDiagnostics);
+  validateSetupTeardown(options);
+}
+
 export function validateCallback(callback: unknown): void {
   if (typeof callback !== 'function') {
     throw new TypeError(`jest-performance-matchers: expected value must be a function, received ${typeof callback}`);
@@ -57,19 +101,8 @@ export function validateQuantileOptions(options: {
   if (!Number.isInteger(options.quantile) || options.quantile < 1 || options.quantile > 100) {
     throw new Error(`jest-performance-matchers: quantile must be an integer between 1 and 100, received ${options.quantile}`);
   }
-  if (options.warmup !== undefined && (!Number.isInteger(options.warmup) || options.warmup < 0)) {
-    throw new Error(`jest-performance-matchers: warmup must be a non-negative integer, received ${options.warmup}`);
-  }
-  if (options.outliers !== undefined && options.outliers !== 'remove' && options.outliers !== 'keep') {
-    throw new Error(`jest-performance-matchers: outliers must be 'remove' or 'keep', received '${options.outliers}'`);
-  }
-  if (options.allowedErrorRate !== undefined) {
-    if (typeof options.allowedErrorRate !== 'number' || !Number.isFinite(options.allowedErrorRate) || options.allowedErrorRate < 0 || options.allowedErrorRate > 1) {
-      throw new Error(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${options.allowedErrorRate}`);
-    }
-  }
-  validateLogDiagnostics(options.logDiagnostics);
-  validateSetupTeardown(options);
+  validateWarmup(options.warmup);
+  validateCommonTail(options);
 }
 
 export function validateComparativeOptions(options: {
@@ -90,29 +123,23 @@ export function validateComparativeOptions(options: {
   if (!Number.isInteger(options.iterations) || options.iterations < 2) {
     throw new Error(`jest-performance-matchers: iterations must be an integer >= 2 for comparative matchers (Welch's t-test requires n >= 2 per function), received ${options.iterations}`);
   }
-  if (options.warmup !== undefined && (!Number.isInteger(options.warmup) || options.warmup < 0)) {
-    throw new Error(`jest-performance-matchers: warmup must be a non-negative integer, received ${options.warmup}`);
-  }
-  if (options.confidence !== undefined) {
-    if (typeof options.confidence !== 'number' || !Number.isFinite(options.confidence) || options.confidence <= 0 || options.confidence >= 1) {
-      throw new Error(`jest-performance-matchers: confidence must be a number between 0 (exclusive) and 1 (exclusive), received ${options.confidence}`);
-    }
-  }
-  if (options.outliers !== undefined && options.outliers !== 'remove' && options.outliers !== 'keep') {
-    throw new Error(`jest-performance-matchers: outliers must be 'remove' or 'keep', received '${options.outliers}'`);
-  }
-  if (options.allowedErrorRate !== undefined) {
-    if (typeof options.allowedErrorRate !== 'number' || !Number.isFinite(options.allowedErrorRate) || options.allowedErrorRate < 0 || options.allowedErrorRate > 1) {
-      throw new Error(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${options.allowedErrorRate}`);
-    }
-  }
-  validateLogDiagnostics(options.logDiagnostics);
-  validateSetupTeardown(options);
+  validateWarmup(options.warmup);
+  validateConfidence(options.confidence);
+  validateCommonTail(options);
 }
 
 export function validateExpectedOpsPerSecond(expectedOpsPerSecond: number): void {
   if (typeof expectedOpsPerSecond !== 'number' || !Number.isFinite(expectedOpsPerSecond) || expectedOpsPerSecond <= 0) {
     throw new Error(`jest-performance-matchers: expected ops/sec must be a positive number, received ${expectedOpsPerSecond}`);
+  }
+}
+
+function validateDurationOptionsHeader(options: { duration?: unknown }): void {
+  if (!options || typeof options !== 'object') {
+    throw new Error('jest-performance-matchers: options must be an object with duration');
+  }
+  if (typeof options.duration !== 'number' || !Number.isFinite(options.duration) || options.duration <= 0) {
+    throw new Error(`jest-performance-matchers: duration must be a positive number, received ${options.duration}`);
   }
 }
 
@@ -127,23 +154,25 @@ export function validateThroughputOptions(options: {
   allowedErrorRate?: number,
   logDiagnostics?: string,
 }): void {
-  if (!options || typeof options !== 'object') {
-    throw new Error('jest-performance-matchers: options must be an object with duration');
-  }
-  if (typeof options.duration !== 'number' || !Number.isFinite(options.duration) || options.duration <= 0) {
-    throw new Error(`jest-performance-matchers: duration must be a positive number, received ${options.duration}`);
-  }
-  if (options.warmup !== undefined && (!Number.isInteger(options.warmup) || options.warmup < 0)) {
-    throw new Error(`jest-performance-matchers: warmup must be a non-negative integer, received ${options.warmup}`);
-  }
-  if (options.outliers !== undefined && options.outliers !== 'remove' && options.outliers !== 'keep') {
-    throw new Error(`jest-performance-matchers: outliers must be 'remove' or 'keep', received '${options.outliers}'`);
-  }
-  if (options.allowedErrorRate !== undefined) {
-    if (typeof options.allowedErrorRate !== 'number' || !Number.isFinite(options.allowedErrorRate) || options.allowedErrorRate < 0 || options.allowedErrorRate > 1) {
-      throw new Error(`jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received ${options.allowedErrorRate}`);
-    }
-  }
-  validateLogDiagnostics(options.logDiagnostics);
-  validateSetupTeardown(options);
+  validateDurationOptionsHeader(options);
+  validateWarmup(options.warmup);
+  validateCommonTail(options);
+}
+
+export function validateComparativeThroughputOptions(options: {
+  duration: number,
+  warmup?: number,
+  confidence?: number,
+  outliers?: 'remove' | 'keep',
+  setup?: unknown,
+  teardown?: unknown,
+  setupEach?: unknown,
+  teardownEach?: unknown,
+  allowedErrorRate?: number,
+  logDiagnostics?: string,
+}): void {
+  validateDurationOptionsHeader(options);
+  validateWarmup(options.warmup);
+  validateConfidence(options.confidence);
+  validateCommonTail(options);
 }

--- a/test/matchers-comparative-throughput.test.ts
+++ b/test/matchers-comparative-throughput.test.ts
@@ -1,0 +1,1332 @@
+import '../src/main';
+import {processComparativeThroughputResults} from '../src/helpers';
+import {mockComparativeThroughputTimings} from './test-utils';
+
+describe("toHaveHigherThroughputThan", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("pass", () => {
+    test("should pass when Function A has higher throughput than Function B", () => {
+      // GIVEN Function A completes 10 fast ops while B completes 5 slow ops in the same duration
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting A has higher throughput than B
+      // THEN the assertion passes
+      expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+    });
+
+    test("should pass when warmup iterations are configured", () => {
+      // GIVEN Function A is faster than Function B
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting with 2 warmup iterations
+      // THEN the assertion passes
+      expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration, warmup: 2});
+    });
+
+    test("should pass when outlier removal is enabled", () => {
+      // GIVEN Function A has an outlier op, Function B is consistently slow
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 500];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting with outlier removal enabled
+      // THEN the assertion passes after outliers are cleaned from per-op stats
+      expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration, outliers: 'remove'});
+    });
+
+    test("should pass with custom confidence level", () => {
+      // GIVEN Function A is faster than Function B
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting with a relaxed confidence level
+      // THEN the assertion passes
+      expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration, confidence: 0.90});
+    });
+
+    test("should default confidence to 0.95 when not specified", () => {
+      // GIVEN Function A is faster than Function B
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting without specifying confidence
+      // THEN the assertion passes with the default confidence of 0.95
+      expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+    });
+
+    test("should default warmup to 0 when not specified", () => {
+      // GIVEN Function A is faster than Function B
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      const givenCallbackA = jest.fn();
+      const givenCallbackB = jest.fn();
+
+      // WHEN asserting without specifying warmup
+      expect(givenCallbackA).toHaveHigherThroughputThan(givenCallbackB, {duration: givenDuration});
+
+      // THEN each callback is called exactly once per measurement op (no warmup)
+      expect(givenCallbackA).toHaveBeenCalledTimes(10);
+      expect(givenCallbackB).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe("fail", () => {
+    test("should fail when Function A has similar throughput to Function B", () => {
+      // GIVEN both functions complete the same number of ops at the same speed
+      const givenDurationsA = [10, 10, 10, 10, 10];
+      const givenDurationsB = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting A has higher throughput than B
+      // THEN the assertion fails (no statistically significant difference)
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      }).toThrow('expected Function A to have higher throughput than Function B');
+    });
+
+    test("should fail when Function A has lower throughput than Function B", () => {
+      // GIVEN Function A is slower than Function B
+      const givenDurationsA = [20, 20, 20, 20, 20];
+      const givenDurationsB = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting A has higher throughput than B
+      // THEN the assertion fails
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      }).toThrow('no statistically significant difference');
+    });
+
+    test("should include diagnostic stats in failure message", () => {
+      // GIVEN both functions have similar throughput
+      const givenDurationsA = [10, 10, 10, 10, 10];
+      const givenDurationsB = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN the comparison assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the failure message includes per-function throughput and comparison diagnostics
+      expect(actualMessage).toContain('--- Function A ---');
+      expect(actualMessage).toContain('--- Function B ---');
+      expect(actualMessage).toContain('--- Comparison ---');
+      expect(actualMessage).toContain('Throughput:');
+      expect(actualMessage).toContain('Per-operation timing');
+      expect(actualMessage).toContain("Welch's t-test");
+      expect(actualMessage).toContain('Result:');
+    });
+  });
+
+  describe(".not", () => {
+    test("should pass with .not when A does NOT have higher throughput", () => {
+      // GIVEN Function A is slower than Function B
+      const givenDurationsA = [20, 20, 20, 20, 20];
+      const givenDurationsB = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting .not
+      // THEN the negated assertion passes
+      expect(() => undefined).not.toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+    });
+
+    test("should fail with .not when A genuinely has higher throughput", () => {
+      // GIVEN Function A is much faster than Function B
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting .not against a clear winner
+      // THEN the negated assertion fails
+      expect(() => {
+        expect(() => undefined).not.toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      }).toThrow('expected Function A NOT to have higher throughput than Function B');
+    });
+  });
+
+  describe("diagnostics", () => {
+    test("should show both functions' throughput in comparison section", () => {
+      // GIVEN both functions have similar throughput
+      const givenDurationsA = [10, 10, 10, 10, 10];
+      const givenDurationsB = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN the assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the message shows per-function throughput in ops/sec
+      expect(actualMessage).toContain('Throughput: A=5 ops/sec, B=5 ops/sec');
+    });
+
+    test("should show setup/teardown active hint when hooks are provided", () => {
+      // GIVEN both functions have similar throughput, with setup hook configured
+      const givenDurationsA = [10, 10, 10, 10, 10];
+      const givenDurationsB = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN the assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {
+          duration: givenDuration, setup: () => undefined,
+        });
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the message includes setup/teardown active hint
+      expect(actualMessage).toContain('setup/teardown active');
+    });
+
+    test("should NOT show setup/teardown hint when no hooks provided", () => {
+      // GIVEN both functions have similar throughput without hooks
+      const givenDurationsA = [10, 10, 10, 10, 10];
+      const givenDurationsB = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN the assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the message does NOT include setup/teardown active hint
+      expect(actualMessage).not.toContain('setup/teardown active');
+    });
+
+    test("should show higher-by line when A is faster in passing .not assertion", () => {
+      // GIVEN Function A is much faster than Function B
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN the .not assertion fails (A is faster)
+      let actualMessage = '';
+      try {
+        expect(() => undefined).not.toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the comparison line shows Function A is higher
+      expect(actualMessage).toContain('Function A is higher by');
+    });
+
+    test("should show lower-by line when A is slower", () => {
+      // GIVEN Function A is slower than Function B
+      const givenDurationsA = [20, 20, 20, 20, 20];
+      const givenDurationsB = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN the assertion fails
+      let actualMessage = '';
+      try {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the comparison line shows Function A is lower
+      expect(actualMessage).toContain('Function A is lower by');
+    });
+  });
+
+  describe("setup/teardown lifecycle", () => {
+    test("should call suite setup once and pass state to both callbacks", () => {
+      // GIVEN both functions run with a shared suite setup
+      const givenDurationsA = [10, 10];
+      const givenDurationsB = [10, 10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      const givenSuiteState = "foo-suite";
+      const actualArgsA: unknown[] = [];
+      const actualArgsB: unknown[] = [];
+
+      // WHEN the comparison assertion runs
+      try {
+        expect((data: unknown) => { actualArgsA.push(data); }).toHaveHigherThroughputThan(
+          (data: unknown) => { actualArgsB.push(data); },
+          {duration: givenDuration, setup: () => givenSuiteState},
+        );
+      } catch { /* may fail, but we only care about the state passing */ }
+
+      // THEN both callbacks receive the shared suite state
+      expect(actualArgsA).toEqual([givenSuiteState, givenSuiteState]);
+      expect(actualArgsB).toEqual([givenSuiteState, givenSuiteState]);
+    });
+
+    test("should call suite teardown once after both measurements", () => {
+      // GIVEN both functions run with a suite teardown
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      const givenSuiteState = "foo-state";
+      const actualTeardownArgs: unknown[] = [];
+
+      // WHEN the comparison assertion runs
+      try {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {
+          duration: givenDuration,
+          setup: () => givenSuiteState,
+          teardown: (state) => { actualTeardownArgs.push(state); },
+        });
+      } catch { /* may fail but teardown is independent */ }
+
+      // THEN teardown is called exactly once with the suite state
+      expect(actualTeardownArgs).toEqual([givenSuiteState]);
+    });
+
+    test("should call teardown even when callback throws and allowedErrorRate is 0", () => {
+      // GIVEN Function A throws on first op
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      let actualTeardownCalled = false;
+
+      // WHEN the callback throws during measurement
+      try {
+        expect(() => { throw new Error("foo-error"); }).toHaveHigherThroughputThan(() => undefined, {
+          duration: givenDuration,
+          teardown: () => { actualTeardownCalled = true; },
+        });
+      } catch { /* expected */ }
+
+      // THEN teardown is still called
+      expect(actualTeardownCalled).toBe(true);
+    });
+
+    test("should call setupEach/teardownEach per operation for both functions", () => {
+      // GIVEN both functions run with per-op hooks
+      const givenDurationsA = [10, 10];
+      const givenDurationsB = [10, 10, 10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      let actualSetupEachCount = 0;
+      let actualTeardownEachCount = 0;
+
+      // WHEN the comparison assertion runs
+      try {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {
+          duration: givenDuration,
+          setupEach: () => { actualSetupEachCount++; },
+          teardownEach: () => { actualTeardownEachCount++; },
+        });
+      } catch { /* may fail */ }
+
+      // THEN per-op hooks are called once per operation across both functions (2 + 3 = 5)
+      expect(actualSetupEachCount).toBe(5);
+      expect(actualTeardownEachCount).toBe(5);
+    });
+
+    test("should call setupEach/teardownEach during warmup for both functions", () => {
+      // GIVEN both functions run with warmup and per-op hooks
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      let actualSetupEachCount = 0;
+      let actualTeardownEachCount = 0;
+
+      // WHEN the comparison assertion runs with 2 warmup iterations
+      try {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {
+          duration: givenDuration, warmup: 2,
+          setupEach: () => { actualSetupEachCount++; },
+          teardownEach: () => { actualTeardownEachCount++; },
+        });
+      } catch { /* may fail */ }
+
+      // THEN per-op hooks fire during both warmup (2*2 = 4) and measurement (1+1 = 2)
+      expect(actualSetupEachCount).toBe(6);
+      expect(actualTeardownEachCount).toBe(6);
+    });
+
+    test("should propagate setupEach error immediately", () => {
+      // GIVEN setupEach throws
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN setupEach throws during warmup/measurement
+      // THEN the error propagates immediately
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {
+          duration: givenDuration,
+          setupEach: () => { throw new Error("foo-setup-error"); },
+        });
+      }).toThrow("foo-setup-error");
+    });
+
+    test("should pass suite state and iter state to callbacks in correct order", () => {
+      // GIVEN suite and per-op setup provide state
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      const givenSuiteState = "foo-suite";
+      let iterCounter = 0;
+      const actualArgsA: unknown[][] = [];
+      const actualArgsB: unknown[][] = [];
+
+      // WHEN the assertion runs
+      try {
+        expect((...args: unknown[]) => { actualArgsA.push([...args]); }).toHaveHigherThroughputThan(
+          (...args: unknown[]) => { actualArgsB.push([...args]); },
+          {
+            duration: givenDuration,
+            setup: () => givenSuiteState,
+            setupEach: () => `foo-iter-${++iterCounter}`,
+          },
+        );
+      } catch { /* may fail */ }
+
+      // THEN both callbacks receive [suiteState, iterState]
+      expect(actualArgsA).toEqual([[givenSuiteState, "foo-iter-1"]]);
+      expect(actualArgsB).toEqual([[givenSuiteState, "foo-iter-2"]]);
+    });
+  });
+
+  describe("error rate", () => {
+    test("should propagate Function A error immediately when allowedErrorRate is 0", () => {
+      // GIVEN Function A throws
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting without error tolerance
+      // THEN Function A's error propagates immediately
+      expect(() => {
+        expect(() => { throw new Error("foo-error-A"); }).toHaveHigherThroughputThan(
+          () => undefined, {duration: givenDuration},
+        );
+      }).toThrow("foo-error-A");
+    });
+
+    test("should propagate Function B error immediately when allowedErrorRate is 0", () => {
+      // GIVEN Function B throws (A succeeds)
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting without error tolerance
+      // THEN Function B's error propagates immediately
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(
+          () => { throw new Error("foo-error-B"); }, {duration: givenDuration},
+        );
+      }).toThrow("foo-error-B");
+    });
+
+    test("should fail when Function A error rate exceeds allowed tolerance", () => {
+      // GIVEN Function A has 3 errors out of 5, Function B has none
+      const givenDurationsA = [10, 10, 10, 10, 10];
+      const givenDurationsB = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const errorIndicesA = new Set([0, 1, 2]);
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration, errorIndicesA);
+      let callCountA = 0;
+
+      // WHEN the assertion runs with only 10% tolerance
+      expect(() => {
+        expect(() => {
+          callCountA++;
+          if (callCountA <= 3) throw new Error("foo-error-A");
+        }).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration, allowedErrorRate: 0.1});
+      }).toThrow('Function A: error rate');
+    });
+
+    test("should fail when Function B error rate exceeds allowed tolerance (integration)", () => {
+      // GIVEN Function A is clean, Function B has 3 errors out of 5
+      const givenDurationsA = [10, 10, 10, 10, 10];
+      const givenDurationsB = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      const errorIndicesB = new Set([0, 1, 2]);
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration, undefined, errorIndicesB);
+      let callCountB = 0;
+
+      // WHEN the assertion runs with only 10% tolerance
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => {
+          callCountB++;
+          if (callCountB <= 3) throw new Error("foo-error-B");
+        }, {duration: givenDuration, allowedErrorRate: 0.1});
+      }).toThrow('Function B: error rate');
+    });
+
+    test("should tolerate errors within allowed rate for both functions", () => {
+      // GIVEN Function A has 1 error out of 10, Function B has 1 error out of 5, both within tolerance
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      const errorIndicesA = new Set([5]);
+      const errorIndicesB = new Set([2]);
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration, errorIndicesA, errorIndicesB);
+      let callCountA = 0;
+      let callCountB = 0;
+
+      // WHEN asserting with allowedErrorRate=0.5
+      // THEN the assertion passes with errors tolerated
+      expect(() => {
+        callCountA++;
+        if (callCountA === 6) throw new Error("foo-error-A");
+      }).toHaveHigherThroughputThan(() => {
+        callCountB++;
+        if (callCountB === 3) throw new Error("foo-error-B");
+      }, {duration: givenDuration, allowedErrorRate: 0.5});
+    });
+
+    test("should show all-failed message when Function A has all errors", () => {
+      // GIVEN Function A has all operations fail
+      const givenDurationsA = [10, 10, 10];
+      const givenDurationsB = [10, 10, 10];
+      const givenDuration = 1000;
+      const errorIndicesA = new Set([0, 1, 2]);
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration, errorIndicesA);
+
+      // WHEN all of A's operations fail
+      expect(() => {
+        expect(() => { throw new Error("foo-error-A"); }).toHaveHigherThroughputThan(
+          () => undefined, {duration: givenDuration, allowedErrorRate: 1},
+        );
+      }).toThrow('Function A: all 3 operations failed');
+    });
+  });
+
+  describe("outlier removal", () => {
+    test("should keep outliers by default", () => {
+      // GIVEN Function A is fast but has an outlier op, Function B is consistently fast
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 500];
+      const givenDurationsB = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting without outlier removal (default)
+      // THEN the outlier in A inflates variance and the test reports no significant difference
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      }).toThrow('no statistically significant difference');
+    });
+
+    test("should remove outliers when enabled", () => {
+      // GIVEN Function A has one outlier op, Function B is consistently slower
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 500];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting with outlier removal enabled
+      // THEN outlier is removed from per-op stats and A's advantage becomes statistically significant
+      expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration, outliers: 'remove'});
+    });
+  });
+
+  describe("edge cases", () => {
+    test("should fail with insufficient data message when Function A has n=1", () => {
+      // GIVEN Function A only completes 1 op in the window
+      const givenDurationsA = [10];
+      const givenDurationsB = [10, 10, 10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting
+      // THEN the result fails with insufficient data for Welch's t-test
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      }).toThrow('Function A: insufficient data after processing (n=1)');
+    });
+
+    test("should fail with insufficient data message when Function B has n=1", () => {
+      // GIVEN Function B only completes 1 op in the window
+      const givenDurationsA = [10, 10, 10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting
+      // THEN the result fails with insufficient data for Welch's t-test
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+      }).toThrow('Function B: insufficient data after processing (n=1)');
+    });
+  });
+
+  describe("input validation", () => {
+    test("should throw when received value is not a function", () => {
+      expect(() => {
+        expect(42).toHaveHigherThroughputThan(() => undefined, {duration: 1000});
+      }).toThrow("jest-performance-matchers: expected value must be a function, received number");
+    });
+
+    test("should throw when comparison function is not a function", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing non-function
+        expect(() => undefined).toHaveHigherThroughputThan(42, {duration: 1000});
+      }).toThrow("jest-performance-matchers: expected value must be a function, received number");
+    });
+
+    test("should throw when options is null", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(
+          () => undefined, null as unknown as {duration: number},
+        );
+      }).toThrow("jest-performance-matchers: options must be an object with duration");
+    });
+
+    test("should throw when duration is negative", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: -1});
+      }).toThrow("jest-performance-matchers: duration must be a positive number, received -1");
+    });
+
+    test("should throw when duration is zero", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 0});
+      }).toThrow("jest-performance-matchers: duration must be a positive number, received 0");
+    });
+
+    test("should throw when duration is NaN", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: NaN});
+      }).toThrow("jest-performance-matchers: duration must be a positive number, received NaN");
+    });
+
+    test("should throw when duration is Infinity", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: Infinity});
+      }).toThrow("jest-performance-matchers: duration must be a positive number, received Infinity");
+    });
+
+    test("should throw when warmup is negative", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, warmup: -1});
+      }).toThrow("jest-performance-matchers: warmup must be a non-negative integer, received -1");
+    });
+
+    test("should throw when warmup is non-integer", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, warmup: 1.5});
+      }).toThrow("jest-performance-matchers: warmup must be a non-negative integer, received 1.5");
+    });
+
+    test("should throw when confidence is zero", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, confidence: 0});
+      }).toThrow("jest-performance-matchers: confidence must be a number between 0 (exclusive) and 1 (exclusive), received 0");
+    });
+
+    test("should throw when confidence is one", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, confidence: 1});
+      }).toThrow("jest-performance-matchers: confidence must be a number between 0 (exclusive) and 1 (exclusive), received 1");
+    });
+
+    test("should throw when confidence is negative", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, confidence: -0.1});
+      }).toThrow("jest-performance-matchers: confidence must be a number between 0 (exclusive) and 1 (exclusive), received -0.1");
+    });
+
+    test("should throw when confidence is greater than 1", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, confidence: 1.5});
+      }).toThrow("jest-performance-matchers: confidence must be a number between 0 (exclusive) and 1 (exclusive), received 1.5");
+    });
+
+    test("should throw when confidence is NaN", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, confidence: NaN});
+      }).toThrow("jest-performance-matchers: confidence must be a number between 0 (exclusive) and 1 (exclusive), received NaN");
+    });
+
+    test("should throw when confidence is not a number", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing non-number
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, confidence: 'high'});
+      }).toThrow("jest-performance-matchers: confidence must be a number between 0 (exclusive) and 1 (exclusive), received high");
+    });
+
+    test("should throw when outliers is invalid string", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing invalid outliers
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, outliers: 'invalid'});
+      }).toThrow("jest-performance-matchers: outliers must be 'remove' or 'keep', received 'invalid'");
+    });
+
+    test("should throw when allowedErrorRate exceeds 1", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, allowedErrorRate: 1.5});
+      }).toThrow("jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received 1.5");
+    });
+
+    test("should throw when allowedErrorRate is negative", () => {
+      expect(() => {
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, allowedErrorRate: -0.1});
+      }).toThrow("jest-performance-matchers: allowedErrorRate must be a number between 0 and 1, received -0.1");
+    });
+
+    test("should throw when logDiagnostics is invalid", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing invalid logDiagnostics
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, logDiagnostics: 'BAD'});
+      }).toThrow("jest-performance-matchers: logDiagnostics must be 'INFO', 'WARN', or 'FAIL', received 'BAD'");
+    });
+
+    test("should throw when setup is not a function", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing non-function setup
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, setup: 42});
+      }).toThrow("jest-performance-matchers: setup must be a function if provided, received number");
+    });
+
+    test("should throw when teardown is not a function", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing non-function teardown
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, teardown: 42});
+      }).toThrow("jest-performance-matchers: teardown must be a function if provided, received number");
+    });
+
+    test("should throw when setupEach is not a function", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing non-function setupEach
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, setupEach: 42});
+      }).toThrow("jest-performance-matchers: setupEach must be a function if provided, received number");
+    });
+
+    test("should throw when teardownEach is not a function", () => {
+      expect(() => {
+        // @ts-expect-error - intentionally passing non-function teardownEach
+        expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: 1000, teardownEach: 42});
+      }).toThrow("jest-performance-matchers: teardownEach must be a function if provided, received number");
+    });
+  });
+});
+
+describe("toResolveWithHigherThroughputThan", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("pass", () => {
+    test("should pass when async A has higher throughput than async B", async () => {
+      // GIVEN async Function A completes more ops than B in the same window
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting A has higher throughput than B
+      // THEN the assertion passes
+      await expect(async () => undefined).toResolveWithHigherThroughputThan(
+        async () => undefined, {duration: givenDuration},
+      );
+    });
+
+    test("should pass with warmup configured", async () => {
+      // GIVEN async Function A is faster
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting with 2 warmup iterations
+      // THEN the assertion passes
+      await expect(async () => undefined).toResolveWithHigherThroughputThan(
+        async () => undefined, {duration: givenDuration, warmup: 2},
+      );
+    });
+  });
+
+  describe("fail", () => {
+    test("should fail when async functions have similar throughput", async () => {
+      // GIVEN both async functions have similar speed
+      const givenDurationsA = [10, 10, 10, 10, 10];
+      const givenDurationsB = [10, 10, 10, 10, 10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN the comparison assertion fails
+      let actualMessage = '';
+      try {
+        await expect(async () => undefined).toResolveWithHigherThroughputThan(
+          async () => undefined, {duration: givenDuration},
+        );
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the failure message is framed in throughput terms
+      expect(actualMessage).toContain('expected Function A to have higher throughput than Function B');
+    });
+  });
+
+  describe(".not", () => {
+    test("should pass with .not when async A is not faster", async () => {
+      // GIVEN async Function A is slower than B
+      const givenDurationsA = [20, 20, 20, 20, 20];
+      const givenDurationsB = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting .not
+      // THEN the negated assertion passes
+      await expect(async () => undefined).not.toResolveWithHigherThroughputThan(
+        async () => undefined, {duration: givenDuration},
+      );
+    });
+
+    test("should fail with .not when async A genuinely has higher throughput", async () => {
+      // GIVEN async Function A is much faster than B
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting .not against a clear winner
+      let actualMessage = '';
+      try {
+        await expect(async () => undefined).not.toResolveWithHigherThroughputThan(
+          async () => undefined, {duration: givenDuration},
+        );
+      } catch (e) {
+        actualMessage = (e as Error).message;
+      }
+
+      // THEN the .not assertion fails
+      expect(actualMessage).toContain('expected Function A NOT to have higher throughput than Function B');
+    });
+  });
+
+  describe("async setup/teardown", () => {
+    test("should call async suite setup once and pass state to both callbacks", async () => {
+      // GIVEN both async functions share suite state
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      const givenSuiteState = "foo-async-state";
+      const actualArgsA: unknown[] = [];
+      const actualArgsB: unknown[] = [];
+
+      // WHEN the async assertion runs
+      try {
+        await expect(async (data: unknown) => { actualArgsA.push(data); }).toResolveWithHigherThroughputThan(
+          async (data: unknown) => { actualArgsB.push(data); },
+          {duration: givenDuration, setup: async () => givenSuiteState},
+        );
+      } catch { /* may fail */ }
+
+      // THEN both callbacks receive the shared suite state
+      expect(actualArgsA).toEqual([givenSuiteState]);
+      expect(actualArgsB).toEqual([givenSuiteState]);
+    });
+
+    test("should call async teardown even when callback rejects", async () => {
+      // GIVEN async Function A rejects
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      let actualTeardownCalled = false;
+
+      // WHEN the async callback rejects during measurement
+      try {
+        await expect(async () => { throw new Error("foo-async-error"); }).toResolveWithHigherThroughputThan(
+          async () => undefined, {
+            duration: givenDuration,
+            teardown: async () => { actualTeardownCalled = true; },
+          },
+        );
+      } catch { /* expected */ }
+
+      // THEN teardown is still called
+      expect(actualTeardownCalled).toBe(true);
+    });
+
+    test("should call async setupEach/teardownEach for both functions including warmup", async () => {
+      // GIVEN both async functions run with per-op hooks and warmup
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+      let actualSetupEachCount = 0;
+      let actualTeardownEachCount = 0;
+
+      // WHEN the assertion runs with 1 warmup iteration
+      try {
+        await expect(async () => undefined).toResolveWithHigherThroughputThan(
+          async () => undefined, {
+            duration: givenDuration, warmup: 1,
+            setupEach: async () => { actualSetupEachCount++; },
+            teardownEach: async () => { actualTeardownEachCount++; },
+          },
+        );
+      } catch { /* may fail */ }
+
+      // THEN per-op hooks fire during warmup (1*2) and measurement (1+1)
+      expect(actualSetupEachCount).toBe(4);
+      expect(actualTeardownEachCount).toBe(4);
+    });
+  });
+
+  describe("async error rate", () => {
+    test("should propagate async A rejection immediately when allowedErrorRate is 0", async () => {
+      // GIVEN async Function A rejects
+      const givenDurationsA = [10];
+      const givenDurationsB = [10];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting without error tolerance
+      // THEN the async rejection propagates
+      await expect(
+        expect(async () => { throw new Error("foo-async-A"); }).toResolveWithHigherThroughputThan(
+          async () => undefined, {duration: givenDuration},
+        ),
+      ).rejects.toThrow("foo-async-A");
+    });
+
+    test("should remove outliers when enabled (async)", async () => {
+      // GIVEN async Function A has an outlier, Function B is consistently slower
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 500];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting with outlier removal enabled
+      // THEN the outlier is removed and A's advantage becomes statistically significant
+      await expect(async () => undefined).toResolveWithHigherThroughputThan(
+        async () => undefined, {duration: givenDuration, outliers: 'remove'},
+      );
+    });
+
+    test("should keep outliers by default (async)", async () => {
+      // GIVEN async Function A has an outlier and B has consistent fast ops
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 500];
+      const givenDurationsB = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDuration = 1000;
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+
+      // WHEN asserting without outlier removal (default)
+      // THEN the outlier inflates variance and no significant difference is detected
+      await expect(async () => {
+        await expect(async () => undefined).toResolveWithHigherThroughputThan(
+          async () => undefined, {duration: givenDuration},
+        );
+      }).rejects.toThrow('no statistically significant difference');
+    });
+
+    test("should tolerate async errors within allowed rate", async () => {
+      // GIVEN async A and B both have some errors within tolerance
+      const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+      const givenDurationsB = [20, 20, 20, 20, 20];
+      const givenDuration = 1000;
+      const errorIndicesA = new Set([5]);
+      mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration, errorIndicesA);
+      let callCountA = 0;
+
+      // WHEN asserting with allowedErrorRate=0.5
+      // THEN the assertion passes
+      await expect(async () => {
+        callCountA++;
+        if (callCountA === 6) throw new Error("foo-async-A");
+      }).toResolveWithHigherThroughputThan(
+        async () => undefined,
+        {duration: givenDuration, allowedErrorRate: 0.5},
+      );
+    });
+  });
+
+  describe("async input validation", () => {
+    test("should throw when received value is not a function", async () => {
+      await expect(async () => {
+        await expect(42).toResolveWithHigherThroughputThan(async () => undefined, {duration: 1000});
+      }).rejects.toThrow("jest-performance-matchers: expected value must be a function, received number");
+    });
+
+    test("should throw when comparison function is not a function", async () => {
+      await expect(async () => {
+        // @ts-expect-error - intentionally passing non-function
+        await expect(async () => undefined).toResolveWithHigherThroughputThan(42, {duration: 1000});
+      }).rejects.toThrow("jest-performance-matchers: expected value must be a function, received number");
+    });
+
+    test("should throw when duration is negative", async () => {
+      await expect(async () => {
+        await expect(async () => undefined).toResolveWithHigherThroughputThan(async () => undefined, {duration: -1});
+      }).rejects.toThrow("jest-performance-matchers: duration must be a positive number, received -1");
+    });
+
+    test("should throw when confidence is invalid", async () => {
+      await expect(async () => {
+        await expect(async () => undefined).toResolveWithHigherThroughputThan(
+          async () => undefined, {duration: 1000, confidence: 0},
+        );
+      }).rejects.toThrow("jest-performance-matchers: confidence must be a number between 0 (exclusive) and 1 (exclusive), received 0");
+    });
+  });
+});
+
+describe("logDiagnostics option (toHaveHigherThroughputThan)", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("should log via console.info on passing test when logDiagnostics is 'INFO'", () => {
+    // GIVEN Function A has clearly higher throughput
+    const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+    const givenDurationsB = [20, 20, 20, 20, 20];
+    const givenDuration = 1000;
+    mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {
+      duration: givenDuration, logDiagnostics: 'INFO',
+    });
+
+    // THEN console.info is called with the diagnostics block
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics:');
+  });
+
+  test("should log via console.warn on passing test with warnings (default WARN)", () => {
+    // GIVEN Function A is much faster with tiny sample sizes (triggering POOR sample adequacy)
+    const givenDurationsA = [1, 1];
+    const givenDurationsB = [100, 100];
+    const givenDuration = 1000;
+    mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    // WHEN asserting with default logDiagnostics (WARN)
+    expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+
+    // THEN console.warn is called because small sample triggers POOR sample adequacy
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics (warnings detected):');
+  });
+
+  test("should not log on passing test when logDiagnostics is 'FAIL'", () => {
+    // GIVEN Function A is much faster (with warnings present)
+    const givenDurationsA = [1, 1];
+    const givenDurationsB = [100, 100];
+    const givenDuration = 1000;
+    mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'FAIL'
+    expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {
+      duration: givenDuration, logDiagnostics: 'FAIL',
+    });
+
+    // THEN no console output
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test("should not log on passing test when WARN and no warnings", () => {
+    // GIVEN both functions have large, consistent samples with no warning conditions
+    const givenDurationsA = Array(35).fill(1);
+    const givenDurationsB = Array(35).fill(20);
+    const givenDuration = 1000;
+    mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with default logDiagnostics (WARN)
+    expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {duration: givenDuration});
+
+    // THEN no console output (no warning conditions)
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  test("should not log on failing test regardless of logDiagnostics level", () => {
+    // GIVEN both functions have identical throughput (assertion will fail)
+    const givenDurationsA = [10, 10, 10, 10, 10];
+    const givenDurationsB = [10, 10, 10, 10, 10];
+    const givenDuration = 1000;
+    mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN the assertion fails with logDiagnostics: 'INFO'
+    expect(() => {
+      expect(() => undefined).toHaveHigherThroughputThan(() => undefined, {
+        duration: givenDuration, logDiagnostics: 'INFO',
+      });
+    }).toThrow();
+
+    // THEN no console output (failures always show diagnostics in message instead)
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("logDiagnostics option (toResolveWithHigherThroughputThan)", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("should log via console.info on passing async test with 'INFO'", async () => {
+    // GIVEN async Function A is much faster
+    const givenDurationsA = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+    const givenDurationsB = [20, 20, 20, 20, 20];
+    const givenDuration = 1000;
+    mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN asserting with logDiagnostics: 'INFO'
+    await expect(async () => undefined).toResolveWithHigherThroughputThan(
+      async () => undefined, {duration: givenDuration, logDiagnostics: 'INFO'},
+    );
+
+    // THEN console.info is called
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('[jest-performance-matchers] Diagnostics:');
+  });
+
+  test("should not log on failing async test with 'INFO'", async () => {
+    // GIVEN async functions with similar throughput (will fail)
+    const givenDurationsA = [10, 10, 10, 10, 10];
+    const givenDurationsB = [10, 10, 10, 10, 10];
+    const givenDuration = 1000;
+    mockComparativeThroughputTimings(givenDurationsA, givenDurationsB, givenDuration);
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    // WHEN the async assertion fails
+    await expect(
+      expect(async () => undefined).toResolveWithHigherThroughputThan(
+        async () => undefined, {duration: givenDuration, logDiagnostics: 'INFO'},
+      ),
+    ).rejects.toThrow();
+
+    // THEN no console output
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("processComparativeThroughputResults", () => {
+  test("should return pass=false when Function A has all operations failed", () => {
+    // GIVEN Function A has 0 successes, all failed
+    const actualResult = processComparativeThroughputResults({
+      durationsA: [], durationsB: [10, 10, 10],
+      totalOpsA: 5, totalOpsB: 3,
+      errorCountA: 5, errorCountB: 0,
+      allowedErrorRate: 1, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the result fails with Function A all-failed message
+    expect(actualResult.pass).toBe(false);
+    expect(actualResult.message()).toContain('Function A: all 5 operations failed');
+  });
+
+  test("should return pass=false when Function B has all operations failed", () => {
+    // GIVEN Function B has 0 successes, all failed
+    const actualResult = processComparativeThroughputResults({
+      durationsA: [10, 10, 10], durationsB: [],
+      totalOpsA: 3, totalOpsB: 5,
+      errorCountA: 0, errorCountB: 5,
+      allowedErrorRate: 1, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the result fails with Function B all-failed message
+    expect(actualResult.pass).toBe(false);
+    expect(actualResult.message()).toContain('Function B: all 5 operations failed');
+  });
+
+  test("should return pass=false when Function A error rate exceeds tolerance", () => {
+    // GIVEN Function A has 3 errors out of 5 with 10% tolerance
+    const actualResult = processComparativeThroughputResults({
+      durationsA: [10, 10], durationsB: [10, 10, 10],
+      totalOpsA: 5, totalOpsB: 3,
+      errorCountA: 3, errorCountB: 0,
+      allowedErrorRate: 0.1, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the result fails
+    expect(actualResult.pass).toBe(false);
+    expect(actualResult.message()).toContain('Function A: error rate 3/5');
+  });
+
+  test("should return pass=false when Function B error rate exceeds tolerance", () => {
+    // GIVEN Function B has 3 errors out of 5 with 10% tolerance
+    const actualResult = processComparativeThroughputResults({
+      durationsA: [10, 10, 10], durationsB: [10, 10],
+      totalOpsA: 3, totalOpsB: 5,
+      errorCountA: 0, errorCountB: 3,
+      allowedErrorRate: 0.1, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the result fails
+    expect(actualResult.pass).toBe(false);
+    expect(actualResult.message()).toContain('Function B: error rate 3/5');
+  });
+
+  test("should pass when A has clearly higher throughput than B", () => {
+    // GIVEN A completes many fast ops while B completes few slow ops
+    const actualResult = processComparativeThroughputResults({
+      durationsA: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      durationsB: [20, 20, 20, 20, 20],
+      totalOpsA: 10, totalOpsB: 5,
+      errorCountA: 0, errorCountB: 0,
+      allowedErrorRate: 0, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the result passes with throughput comparison in message
+    expect(actualResult.pass).toBe(true);
+    expect(actualResult.message()).toContain('Throughput: A=10 ops/sec, B=5 ops/sec');
+  });
+
+  test("should show identical-throughput message when A=B exactly", () => {
+    // GIVEN A and B have identical throughput and timings
+    const actualResult = processComparativeThroughputResults({
+      durationsA: [10, 10, 10, 10, 10],
+      durationsB: [10, 10, 10, 10, 10],
+      totalOpsA: 5, totalOpsB: 5,
+      errorCountA: 0, errorCountB: 0,
+      allowedErrorRate: 0, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the result fails with identical throughput label
+    expect(actualResult.pass).toBe(false);
+    expect(actualResult.message()).toContain('(identical throughput)');
+  });
+
+  test("should show A-trends-faster message when A is faster but not significantly", () => {
+    // GIVEN A is modestly faster than B but sample size is too small for significance
+    const actualResult = processComparativeThroughputResults({
+      durationsA: [10, 11, 9],
+      durationsB: [11, 10, 12],
+      totalOpsA: 3, totalOpsB: 3,
+      errorCountA: 0, errorCountB: 0,
+      allowedErrorRate: 0, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the not-significant message mentions A trending faster
+    expect(actualResult.pass).toBe(false);
+    expect(actualResult.message()).toContain('Function A trends higher by');
+  });
+
+  test("should show modest-difference note when significant with < 5% difference", () => {
+    // GIVEN A has ~3% higher throughput than B with enough data for statistical significance
+    const durationsA: number[] = [];
+    for (let i = 0; i < 103; i++) durationsA.push(5 + (i % 2 === 0 ? 0.05 : -0.05));
+    const durationsB: number[] = [];
+    for (let i = 0; i < 100; i++) durationsB.push(5.15 + (i % 2 === 0 ? 0.05 : -0.05));
+
+    const actualResult = processComparativeThroughputResults({
+      durationsA, durationsB,
+      totalOpsA: durationsA.length, totalOpsB: durationsB.length,
+      errorCountA: 0, errorCountB: 0,
+      allowedErrorRate: 0, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the result passes with modest-difference practical note
+    expect(actualResult.pass).toBe(true);
+    expect(actualResult.message()).toContain('modest (< 5%)');
+  });
+
+  test("should format p-value numerically when p >= 0.0001 in pass message", () => {
+    // GIVEN A is marginally but significantly faster with enough spread to yield p in [0.0001, 0.05)
+    // Per-op means diff by 1ms with stddev ~0.88, n=10 each → one-sided p ≈ 0.01
+    const actualResult = processComparativeThroughputResults({
+      durationsA: [9, 10, 11, 9, 10, 11, 9, 10, 11, 9],
+      durationsB: [10, 11, 12, 10, 11, 12, 10, 11, 12, 10],
+      totalOpsA: 10, totalOpsB: 10,
+      errorCountA: 0, errorCountB: 0,
+      allowedErrorRate: 0, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN pass message includes numerically formatted p-value (not "<0.0001")
+    expect(actualResult.pass).toBe(true);
+    expect(actualResult.message()).toMatch(/but A has statistically significantly higher throughput \(p=0\.\d{4}/);
+    expect(actualResult.message()).not.toMatch(/but A has statistically significantly higher throughput \(p=<0\.0001/);
+  });
+
+  test("should show practically-negligible note when significant with < 1% difference", () => {
+    // GIVEN A has ~0.5% higher throughput than B (201 vs 200 ops) with tight per-op stats for significance
+    const durationsA: number[] = [];
+    for (let i = 0; i < 201; i++) durationsA.push(5 + (i % 2 === 0 ? 0.01 : -0.01));
+    const durationsB: number[] = [];
+    for (let i = 0; i < 200; i++) durationsB.push(5.05 + (i % 2 === 0 ? 0.01 : -0.01));
+
+    const actualResult = processComparativeThroughputResults({
+      durationsA, durationsB,
+      totalOpsA: durationsA.length, totalOpsB: durationsB.length,
+      errorCountA: 0, errorCountB: 0,
+      allowedErrorRate: 0, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the result passes with the "practically negligible" note
+    expect(actualResult.pass).toBe(true);
+    expect(actualResult.message()).toContain('less than 1%');
+    expect(actualResult.message()).toContain('practically negligible');
+  });
+
+  test("should report unreliable comparison when either function has POOR RME", () => {
+    // GIVEN Function A has extremely high per-op variance (POOR RME)
+    const actualResult = processComparativeThroughputResults({
+      durationsA: [1, 100, 1, 100, 1, 100, 1, 100, 1, 100],
+      durationsB: [50, 50, 50, 50, 50, 50, 50, 50, 50, 50],
+      totalOpsA: 10, totalOpsB: 10,
+      errorCountA: 0, errorCountB: 0,
+      allowedErrorRate: 0, confidence: 0.95, duration: 1000,
+      setupTeardownActive: false, removeOutliersEnabled: false, logDiagnostics: 'FAIL',
+    });
+
+    // THEN the diagnostics Result line reports an unreliable comparison
+    expect(actualResult.message()).toContain('comparison is unreliable');
+    expect(actualResult.message()).toContain('POOR RME');
+  });
+});

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -30,19 +30,14 @@ function msToHrtime(ms: number): [number, number] {
 }
 
 /**
- * Mock hrtime for throughput matchers that use a time-bounded while loop.
+ * Build the hrtime value sequence for one time-bounded throughput measurement window.
  *
  * Call pattern for successful ops: loop-check + t0 + t1 = 3 calls each
  * Call pattern for erroring ops: loop-check + t0 = 2 calls each (t1 is never reached)
- * Total: 1 (deadline) + 3*(N-E) + 2*E + 1 (exit check) = 3N - E + 2
- *
- * @param opDurations - array of per-operation durations in ms
- * @param durationWindow - the duration option passed to the matcher (ms)
- * @param errorIndices - optional set of 0-based operation indices that will throw (skips t1 call)
+ * Total per window: 1 (deadline) + 3*(N-E) + 2*E + 1 (exit check) = 3N - E + 2
  */
-export function mockThroughputTimings(opDurations: number[], durationWindow: number, errorIndices?: Set<number>): void {
+function buildThroughputHrtimeValues(opDurations: number[], durationWindow: number, baseMs: number, errorIndices?: Set<number>): [number, number][] {
   const hrtimeValues: [number, number][] = [];
-  const baseMs = 1000; // arbitrary base time
 
   // Call 1: initial timestamp for deadline calculation (deadline = base + durationWindow)
   hrtimeValues.push(msToHrtime(baseMs));
@@ -56,7 +51,6 @@ export function mockThroughputTimings(opDurations: number[], durationWindow: num
 
     if (errorIndices && errorIndices.has(i)) {
       // Error case: callback throws before t1, so no t1 call
-      // Advance time by the op duration for realism
       currentMs += opDurations[i];
     } else {
       // Success case: t1 = end timing (current + opDuration)
@@ -68,10 +62,54 @@ export function mockThroughputTimings(opDurations: number[], durationWindow: num
   // Final loop condition check: past deadline to exit
   hrtimeValues.push(msToHrtime(baseMs + durationWindow + 1));
 
+  return hrtimeValues;
+}
+
+/**
+ * Mock hrtime for throughput matchers that use a time-bounded while loop.
+ *
+ * @param opDurations - array of per-operation durations in ms
+ * @param durationWindow - the duration option passed to the matcher (ms)
+ * @param errorIndices - optional set of 0-based operation indices that will throw (skips t1 call)
+ */
+export function mockThroughputTimings(opDurations: number[], durationWindow: number, errorIndices?: Set<number>): void {
+  const baseMs = 1000; // arbitrary base time
+  const hrtimeValues = buildThroughputHrtimeValues(opDurations, durationWindow, baseMs, errorIndices);
+
   let callIndex = 0;
   jest.spyOn(process, "hrtime").mockImplementation(() => {
     if (callIndex >= hrtimeValues.length) {
       return msToHrtime(baseMs + durationWindow + 1000);
+    }
+    return hrtimeValues[callIndex++];
+  });
+}
+
+/**
+ * Mock hrtime for comparative throughput matchers that run two sequential measurement windows
+ * (Function A, then Function B). The two windows are concatenated: A's exit advances time,
+ * then B's window begins with its own deadline initialization.
+ *
+ * @param opDurationsA - per-operation durations for Function A (ms)
+ * @param opDurationsB - per-operation durations for Function B (ms)
+ * @param durationWindow - the duration option passed to the matcher (ms), same for both functions
+ * @param errorIndicesA - optional set of 0-based operation indices for A that will throw
+ * @param errorIndicesB - optional set of 0-based operation indices for B that will throw
+ */
+export function mockComparativeThroughputTimings(
+  opDurationsA: number[], opDurationsB: number[], durationWindow: number,
+  errorIndicesA?: Set<number>, errorIndicesB?: Set<number>,
+): void {
+  const baseA = 1000;
+  const baseB = baseA + durationWindow + 2; // B starts after A's window has ended
+  const valuesA = buildThroughputHrtimeValues(opDurationsA, durationWindow, baseA, errorIndicesA);
+  const valuesB = buildThroughputHrtimeValues(opDurationsB, durationWindow, baseB, errorIndicesB);
+  const hrtimeValues = [...valuesA, ...valuesB];
+
+  let callIndex = 0;
+  jest.spyOn(process, "hrtime").mockImplementation(() => {
+    if (callIndex >= hrtimeValues.length) {
+      return msToHrtime(baseB + durationWindow + 1000);
     }
     return hrtimeValues[callIndex++];
   });


### PR DESCRIPTION
## Summary

- Add `toHaveHigherThroughputThan` / `toResolveWithHigherThroughputThan` matchers that statistically compare two functions' throughput using time-bounded measurement windows and Welch's t-test on per-op durations
- Refactor: extract shared `warmupSyncInterleaved` / `warmupAsyncInterleaved` into `hooks.ts`; use `formatPValue` helper for consistency in comparative pass/fail messages
- Full diagnostics: per-function throughput (ops/sec) + per-op timing stats, CI, Welch's t-test, and practical significance notes
- 90 new tests (100% statement + branch coverage), runnable examples, README documentation with options reference and diagnostics example

Closes #24

## Test plan

- [x] `npm test` — 722 tests pass, 100% statement + branch coverage
- [x] `npm run lint` — zero errors
- [x] `npm run build` — compiles cleanly
- [x] SonarCloud analysis on all changed files — zero issues
- [x] Examples: `npx jest examples/comparative-throughput.test.ts` — all 8 examples pass against real workloads (Map.get vs Array.find, Set.has vs Array.includes, hash-short vs hash-long, native sort vs bubble sort, async cached vs uncached, stable vs flaky with error tolerance, setup/teardown lifecycle)
- [x] Zero production dependencies maintained